### PR TITLE
feat: add SqlClient database abstraction layer (#141)

### DIFF
--- a/src/db/d1-adapter.ts
+++ b/src/db/d1-adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * Cloudflare D1 adapter for SqlClient interface
+ *
+ * Wraps the native D1Database binding so business code can depend on
+ * the SqlClient interface instead of D1-specific types.
+ */
+
+import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types';
+import type {
+  SqlClient,
+  Statement,
+  BoundStatement,
+  QueryResults,
+  QueryFirstResult,
+  RunResult,
+  BatchResult,
+  QueryResultRow,
+} from './types';
+
+function d1ToStatement(stmt: D1PreparedStatement): BoundStatement {
+  return {
+    all: () => stmt.all() as Promise<QueryResults>,
+    first: <T extends QueryResultRow = QueryResultRow>() =>
+      stmt.first() as Promise<QueryFirstResult<T>>,
+    run: () => stmt.run() as Promise<RunResult>,
+  };
+}
+
+/**
+ * D1 adapter implementing SqlClient interface
+ */
+export class D1Adapter implements SqlClient {
+  constructor(private db: D1Database) {}
+
+  prepare(sql: string): Statement {
+    const stmt = this.db.prepare(sql);
+    return {
+      bind: (...params) => d1ToStatement(stmt.bind(...params)),
+    };
+  }
+
+  async batch(statements: string[]): Promise<BatchResult> {
+    const results = await this.db.batch(statements.map((sql) => this.db.prepare(sql)));
+    return {
+      results: results.map((r) => ({
+        results: [],
+        success: true,
+        meta: r.meta,
+      })) as RunResult[],
+      success: true,
+    };
+  }
+
+  async dump(): Promise<string> {
+    return this.db.dump();
+  }
+
+  async exec(sql: string): Promise<RunResult> {
+    return this.db.exec(sql) as Promise<RunResult>;
+  }
+}
+
+/**
+ * Create a SqlClient from a D1Database binding
+ */
+export function d1Adapter(db: D1Database): SqlClient {
+  return new D1Adapter(db);
+}

--- a/src/db/d1-adapter.ts
+++ b/src/db/d1-adapter.ts
@@ -22,7 +22,7 @@ function d1ToStatement(stmt: D1PreparedStatement): BoundStatement {
     all: () => stmt.all() as Promise<QueryResults>,
     first: <T extends QueryResultRow = QueryResultRow>() =>
       stmt.first() as Promise<QueryFirstResult<T>>,
-    run: () => stmt.run() as Promise<RunResult>,
+    run: () => stmt.run() as unknown as Promise<RunResult>,
   };
 }
 
@@ -52,11 +52,19 @@ export class D1Adapter implements SqlClient {
   }
 
   async dump(): Promise<string> {
-    return this.db.dump();
+    const buffer = await this.db.dump();
+    return new TextDecoder().decode(buffer);
   }
 
   async exec(sql: string): Promise<RunResult> {
-    return this.db.exec(sql) as Promise<RunResult>;
+    const result = await this.db.exec(sql);
+    return {
+      results: [],
+      success: true,
+      meta: {
+        changes: result.count,
+      },
+    };
   }
 }
 

--- a/src/db/factory.ts
+++ b/src/db/factory.ts
@@ -1,0 +1,40 @@
+/**
+ * Factory function to create SqlClient based on runtime environment
+ */
+
+import type { D1Database } from '@cloudflare/workers-types';
+import { D1Adapter, d1Adapter } from './d1-adapter';
+import type { SqlClient } from './types';
+
+export interface SqlClientOptions {
+  d1?: D1Database;
+  // Future: turso options
+  // turso?: { url: string; token: string };
+  // supabase?: { url: string; anonKey: string };
+}
+
+/**
+ * Create a SqlClient based on available environment bindings
+ *
+ * Currently supports D1 (Cloudflare).预留 Turso/Supabase.
+ */
+export function createSqlClient(options: SqlClientOptions): SqlClient {
+  if (options.d1) {
+    return new D1Adapter(options.d1);
+  }
+
+  // Future: Turso support
+  // if (options.turso) {
+  //   return new TursoAdapter(options.turso);
+  // }
+
+  // Future: Supabase support
+  // if (options.supabase) {
+  //   return new SupabaseAdapter(options.supabase);
+  // }
+
+  throw new Error('No database binding provided. Expected D1 or other database client.');
+}
+
+// Re-export d1Adapter for convenience
+export { d1Adapter };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Database abstraction layer (SqlClient)
+ *
+ * Provides a unified interface for database operations across different providers:
+ * - Cloudflare D1
+ * - Turso (libSQL)
+ * - Supabase (PostgreSQL)
+ *
+ * Business code should depend on SqlClient interface, not specific implementations.
+ *
+ * @example
+ * ```typescript
+ * import { createSqlClient, type SqlClient } from '@/db';
+ *
+ * // In Cloudflare Workers
+ * const db: SqlClient = createSqlClient({ d1: env.PLAYBOX_D1 });
+ *
+ * // Query data
+ * const { results } = await db.prepare('SELECT * FROM users').bind(id).all();
+ * ```
+ */
+
+// Types
+export type {
+  SqlClient,
+  Statement,
+  BoundStatement,
+  QueryResults,
+  QueryFirstResult,
+  RunResult,
+  BatchResult,
+  QueryResultRow,
+} from './types';
+
+// Adapters
+export { D1Adapter, d1Adapter } from './d1-adapter';
+export { createSqlClient, type SqlClientOptions } from './factory';

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Database abstraction layer types
+ *
+ * Defines the SqlClient interface that abstracts database operations.
+ * Implementations can be D1, Turso, Supabase, or any SQL database.
+ */
+
+/** A prepared SQL statement that can be executed with bound parameters */
+export interface Statement {
+  bind(...params: (string | number | null | boolean)[]): BoundStatement;
+}
+
+/** An executable statement after binding parameters */
+export interface BoundStatement {
+  all(): Promise<QueryResults>;
+  first<T extends QueryResultRow = QueryResultRow>(): Promise<QueryFirstResult<T>>;
+  run(): Promise<RunResult>;
+}
+
+/** A row returned from a query */
+export type QueryResultRow = Record<string, unknown>;
+
+/** Results from a query that returns multiple rows */
+export interface QueryResults {
+  results: QueryResultRow[];
+  success: boolean;
+  meta?: {
+    changes?: number;
+    last_row_id?: number;
+    rows_read?: number;
+    rows_written?: number;
+  };
+}
+
+/** Result from a query that returns a single row */
+export interface QueryFirstResult<T extends QueryResultRow = QueryResultRow> {
+  results: T | null;
+}
+
+/** Result from an INSERT/UPDATE/DELETE operation */
+export interface RunResult {
+  results: [];
+  success: boolean;
+  meta?: {
+    changes?: number;
+    last_row_id?: number;
+    rows_read?: number;
+    rows_written?: number;
+  };
+}
+
+/** Result from a batch of SQL statements */
+export interface BatchResult {
+  results: RunResult[];
+  success: boolean;
+}
+
+/**
+ * SqlClient interface - abstract database operations
+ *
+ * Business code should depend on this interface, not on specific implementations.
+ * This allows swapping between D1, Turso, Supabase, etc. without changing business logic.
+ */
+export interface SqlClient {
+  prepare(sql: string): Statement;
+  batch(statements: string[]): Promise<BatchResult>;
+  dump(): Promise<string>;
+  exec(sql: string): Promise<RunResult>;
+}


### PR DESCRIPTION
## 概述

为 #141 创建数据库访问抽象层 `SqlClient`。

## 变更内容

```
src/db/
├── types.ts        # SqlClient 接口 + 类型定义
├── d1-adapter.ts   # D1 适配器实现
├── factory.ts      # 工厂函数
└── index.ts        # barrel export
```

## 设计原则

1. **接口命名不暴露实现**：`SqlClient` 而非 `D1Client`
2. **业务代码只依赖接口**：切换实现时无需修改业务代码
3. **预留扩展**：工厂函数中预留了 Turso/Supabase 的创建位置

## 使用方式

```typescript
import { createSqlClient, type SqlClient } from '@/db';

const db: SqlClient = createSqlClient({ d1: env.PLAYBOX_D1 });

// 查询多条
const { results } = await db.prepare('SELECT * FROM providers').bind(key).all();

// 查询单条
const { results: row } = await db.prepare('SELECT * FROM users WHERE id = ?').bind(id).first();

// 执行写操作
await db.prepare('UPDATE users SET name = ? WHERE id = ?').bind(name, id).run();
```

## 待办

- [ ] 重构现有代码使用 SqlClient（作为后续 PR）
- [ ] 编写 SqlClient 单元测试
- [ ] 添加 Turso 适配器
- [ ] 添加 Supabase 适配器

---
Closes #141
