### PR TITLE
feat: add D1 REST API adapter

### DIFF
--- a/src/db/d1-rest-adapter.ts
+++ b/src/db/d1-rest-adapter.ts
@@ -1,0 +1,299 @@
+/**
+ * Cloudflare D1 REST API adapter for SqlClient interface
+ *
+ * Allows accessing D1 databases outside of Cloudflare Workers.
+ * Uses the Cloudflare REST API with Bearer token authentication.
+ *
+ * @example
+ * ```typescript
+ * import { d1RestAdapter } from '@/db';
+ *
+ * const db = d1RestAdapter({
+ *   accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+ *   databaseId: process.env.CLOUDFLARE_DATABASE_ID!,
+ *   apiToken: process.env.CLOUDFLARE_API_TOKEN!,
+ * });
+ *
+ * const { results } = await db.prepare('SELECT * FROM providers').bind(id).all();
+ * ```
+ */
+
+import type {
+  SqlClient,
+  Statement,
+  BoundStatement,
+  QueryResults,
+  QueryFirstResult,
+  RunResult,
+  BatchResult,
+  QueryResultRow,
+} from './types';
+
+/** Configuration for D1 REST API adapter */
+export interface D1RestOptions {
+  /** Cloudflare Account ID */
+  accountId: string;
+  /** D1 Database ID (UUID) */
+  databaseId: string;
+  /** Cloudflare API Token */
+  apiToken: string;
+  /** Optional base URL override */
+  baseUrl?: string;
+}
+
+/** D1 REST API response structure */
+interface D1RestResponse {
+  success: boolean;
+  errors?: Array<{ code: number; message: string }>;
+  result?: D1RestResult[];
+}
+
+interface D1RestResult {
+  success: boolean;
+  meta: {
+    changed_db?: boolean;
+    changes?: number;
+    duration?: number;
+    last_row_id?: number;
+    rows_read?: number;
+    rows_written?: number;
+    size_after?: number;
+  };
+  results?: Record<string, unknown>[];
+}
+
+/**
+ * REST API version of BoundStatement
+ */
+class RestBoundStatement implements BoundStatement {
+  constructor(
+    private fetch: typeof globalThis.fetch,
+    private baseUrl: string,
+    private accountId: string,
+    private databaseId: string,
+    private apiToken: string,
+    private sql: string,
+    private params: (string | number | null | boolean)[]
+  ) {}
+
+  private async execute(): Promise<{ results: Record<string, unknown>[]; meta: QueryResults['meta'] }> {
+    const url = `${this.baseUrl}/client/v4/accounts/${this.accountId}/d1/database/${this.databaseId}/query`;
+
+    const response = await this.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiToken}`,
+      },
+      body: JSON.stringify({
+        sql: this.sql,
+        params: this.params,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`D1 REST API error: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const data = (await response.json()) as D1RestResponse;
+
+    if (!data.success || !data.result?.[0]) {
+      const errorMsg = data.errors?.[0]?.message ?? 'Unknown D1 REST API error';
+      throw new Error(errorMsg);
+    }
+
+    const result = data.result[0];
+    return {
+      results: result.results ?? [],
+      meta: {
+        changes: result.meta.changes,
+        last_row_id: result.meta.last_row_id,
+        rows_read: result.meta.rows_read,
+        rows_written: result.meta.rows_written,
+      },
+    };
+  }
+
+  async all(): Promise<QueryResults> {
+    const { results, meta } = await this.execute();
+    return { results, success: true, meta };
+  }
+
+  async first<T extends QueryResultRow = QueryResultRow>(): Promise<QueryFirstResult<T>> {
+    const { results } = await this.execute();
+    return { results: (results[0] as T) ?? null };
+  }
+
+  async run(): Promise<RunResult> {
+    const { results, meta } = await this.execute();
+    return { results: [], success: true, meta };
+  }
+}
+
+/**
+ * REST API version of Statement
+ */
+class RestStatement {
+  constructor(
+    private fetch: typeof globalThis.fetch,
+    private baseUrl: string,
+    private accountId: string,
+    private databaseId: string,
+    private apiToken: string,
+    private sql: string
+  ) {}
+
+  bind(...params: (string | number | null | boolean)[]): BoundStatement {
+    return new RestBoundStatement(
+      this.fetch,
+      this.baseUrl,
+      this.accountId,
+      this.databaseId,
+      this.apiToken,
+      this.sql,
+      params
+    );
+  }
+}
+
+/**
+ * D1 REST API adapter implementing SqlClient interface
+ */
+export class D1RestAdapter implements SqlClient {
+  private fetch: typeof globalThis.fetch;
+  private baseUrl: string;
+  private accountId: string;
+  private databaseId: string;
+  private apiToken: string;
+
+  constructor(options: D1RestOptions) {
+    this.fetch = globalThis.fetch.bind(globalThis);
+    this.baseUrl = options.baseUrl ?? 'https://api.cloudflare.com';
+    this.accountId = options.accountId;
+    this.databaseId = options.databaseId;
+    this.apiToken = options.apiToken;
+  }
+
+  prepare(sql: string): Statement {
+    return new RestStatement(
+      this.fetch,
+      this.baseUrl,
+      this.accountId,
+      this.databaseId,
+      this.apiToken,
+      sql
+    );
+  }
+
+  async batch(statements: string[]): Promise<BatchResult> {
+    // D1 REST API supports batch in single query with semicolons
+    // But for simplicity, we execute each statement separately
+    const results: RunResult[] = [];
+
+    for (const sql of statements) {
+      const url = `${this.baseUrl}/client/v4/accounts/${this.accountId}/d1/database/${this.databaseId}/query`;
+
+      try {
+        const response = await this.fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiToken}`,
+          },
+          body: JSON.stringify({ sql, params: [] }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          results.push({
+            results: [],
+            success: false,
+            meta: { changes: 0 },
+          });
+          continue;
+        }
+
+        const data = (await response.json()) as D1RestResponse;
+
+        if (!data.success || !data.result?.[0]) {
+          results.push({
+            results: [],
+            success: false,
+            meta: { changes: 0 },
+          });
+          continue;
+        }
+
+        const result = data.result[0];
+        results.push({
+          results: [],
+          success: result.success,
+          meta: {
+            changes: result.meta.changes,
+            last_row_id: result.meta.last_row_id,
+            rows_read: result.meta.rows_read,
+            rows_written: result.meta.rows_written,
+          },
+        });
+      } catch {
+        results.push({
+          results: [],
+          success: false,
+          meta: { changes: 0 },
+        });
+      }
+    }
+
+    return { results, success: results.every((r) => r.success) };
+  }
+
+  async dump(): Promise<string> {
+    // D1 REST API does not support dump/export directly
+    throw new Error('dump() is not supported via D1 REST API. Use wrangler d1 export instead.');
+  }
+
+  async exec(sql: string): Promise<RunResult> {
+    const url = `${this.baseUrl}/client/v4/accounts/${this.accountId}/d1/database/${this.databaseId}/query`;
+
+    const response = await this.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiToken}`,
+      },
+      body: JSON.stringify({ sql, params: [] }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`D1 REST API error: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const data = (await response.json()) as D1RestResponse;
+
+    if (!data.success || !data.result?.[0]) {
+      const errorMsg = data.errors?.[0]?.message ?? 'Unknown D1 REST API error';
+      throw new Error(errorMsg);
+    }
+
+    const result = data.result[0];
+    return {
+      results: [],
+      success: result.success,
+      meta: {
+        changes: result.meta.changes,
+        last_row_id: result.meta.last_row_id,
+        rows_read: result.meta.rows_read,
+        rows_written: result.meta.rows_written,
+      },
+    };
+  }
+}
+
+/**
+ * Create a SqlClient from D1 REST API configuration
+ */
+export function d1RestAdapter(options: D1RestOptions): SqlClient {
+  return new D1RestAdapter(options);
+}

--- a/src/db/factory.ts
+++ b/src/db/factory.ts
@@ -4,10 +4,13 @@
 
 import type { D1Database } from '@cloudflare/workers-types';
 import { D1Adapter, d1Adapter } from './d1-adapter';
+import { D1RestAdapter, d1RestAdapter, type D1RestOptions } from './d1-rest-adapter';
 import type { SqlClient } from './types';
 
 export interface SqlClientOptions {
   d1?: D1Database;
+  /** D1 REST API adapter options */
+  d1Rest?: D1RestOptions;
   // Future: turso options
   // turso?: { url: string; token: string };
   // supabase?: { url: string; anonKey: string };
@@ -23,6 +26,10 @@ export function createSqlClient(options: SqlClientOptions): SqlClient {
     return new D1Adapter(options.d1);
   }
 
+  if (options.d1Rest) {
+    return new D1RestAdapter(options.d1Rest);
+  }
+
   // Future: Turso support
   // if (options.turso) {
   //   return new TursoAdapter(options.turso);
@@ -36,5 +43,5 @@ export function createSqlClient(options: SqlClientOptions): SqlClient {
   throw new Error('No database binding provided. Expected D1 or other database client.');
 }
 
-// Re-export d1Adapter for convenience
-export { d1Adapter };
+// Re-export d1Adapter and d1RestAdapter for convenience
+export { d1Adapter, d1RestAdapter };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -34,4 +34,5 @@ export type {
 
 // Adapters
 export { D1Adapter, d1Adapter } from './d1-adapter';
+export { D1RestAdapter, d1RestAdapter, type D1RestOptions } from './d1-rest-adapter';
 export { createSqlClient, type SqlClientOptions } from './factory';

--- a/test/unit/db/d1-rest-adapter.test.ts
+++ b/test/unit/db/d1-rest-adapter.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for D1 REST API adapter
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { D1RestAdapter, d1RestAdapter, type D1RestOptions } from '../../../src/db/d1-rest-adapter';
+
+describe('D1RestAdapter', () => {
+  const mockOptions: D1RestOptions = {
+    accountId: 'test-account-id',
+    databaseId: 'test-database-id',
+    apiToken: 'test-api-token',
+  };
+
+  const createMockFetch = (responseData: unknown, status = 200) => {
+    return vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: async () => responseData,
+      text: async () => JSON.stringify(responseData),
+    });
+  };
+
+  describe('prepare', () => {
+    it('should return a Statement with bind method', () => {
+      const mockFetch = vi.fn();
+      const adapter = new D1RestAdapter(mockOptions);
+
+      // Access private fetch for testing
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM users');
+      expect(statement).toBeDefined();
+      expect(typeof statement.bind).toBe('function');
+    });
+  });
+
+  describe('bind and execute', () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should execute all() and return query results', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 0, rows_read: 2, rows_written: 0 },
+            results: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }],
+          },
+        ],
+      };
+
+      mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM users WHERE id = ?');
+      const boundStatement = statement.bind(1);
+
+      const result = await boundStatement.all();
+
+      expect(result.success).toBe(true);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0]).toEqual({ id: 1, name: 'Alice' });
+      expect(result.meta?.rows_read).toBe(2);
+    });
+
+    it('should execute first() and return single row', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 0, rows_read: 1 },
+            results: [{ id: 1, name: 'Alice' }],
+          },
+        ],
+      };
+
+      mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM users WHERE id = ?');
+      const boundStatement = statement.bind(1);
+
+      const result = await boundStatement.first();
+
+      expect(result.results).toEqual({ id: 1, name: 'Alice' });
+    });
+
+    it('should return null for first() when no results', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 0, rows_read: 0 },
+            results: [],
+          },
+        ],
+      };
+
+      mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM users WHERE id = ?');
+      const boundStatement = statement.bind(999);
+
+      const result = await boundStatement.first();
+
+      expect(result.results).toBeNull();
+    });
+
+    it('should execute run() for write operations', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 1, rows_written: 1 },
+            results: [],
+          },
+        ],
+      };
+
+      mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('UPDATE users SET name = ? WHERE id = ?');
+      const boundStatement = statement.bind('Charlie', 1);
+
+      const result = await boundStatement.run();
+
+      expect(result.success).toBe(true);
+      expect(result.results).toEqual([]);
+      expect(result.meta?.changes).toBe(1);
+      expect(result.meta?.rows_written).toBe(1);
+    });
+
+    it('should throw error on API failure', async () => {
+      mockFetch = createMockFetch({ success: false, errors: [{ code: 1000, message: 'SQL syntax error' }] }, 400);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM invalid_table');
+      const boundStatement = statement.bind();
+
+      await expect(boundStatement.all()).rejects.toThrow('SQL syntax error');
+    });
+
+    it('should handle HTTP errors', async () => {
+      mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: async () => 'Access denied',
+      });
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT * FROM users');
+      const boundStatement = statement.bind();
+
+      await expect(boundStatement.all()).rejects.toThrow('D1 REST API error: 403 Forbidden');
+    });
+  });
+
+  describe('batch', () => {
+    it('should execute multiple statements', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 0, rows_read: 1 },
+            results: [{ id: 1 }],
+          },
+        ],
+      };
+
+      const mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const result = await adapter.batch(['SELECT 1', 'SELECT 2']);
+
+      expect(result.success).toBe(true);
+      expect(result.results).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return false if any statement fails', async () => {
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            result: [{ success: true, meta: {}, results: [] }],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: false,
+            errors: [{ code: 1000, message: 'Error' }],
+          }),
+        });
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const result = await adapter.batch(['SELECT 1', 'SELECT 2']);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('exec', () => {
+    it('should execute raw SQL', async () => {
+      const mockResponse = {
+        success: true,
+        result: [
+          {
+            success: true,
+            meta: { changes: 5, rows_written: 5 },
+            results: [],
+          },
+        ],
+      };
+
+      const mockFetch = createMockFetch(mockResponse);
+
+      const adapter = new D1RestAdapter(mockOptions);
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const result = await adapter.exec('DELETE FROM users WHERE active = 0');
+
+      expect(result.success).toBe(true);
+      expect(result.meta?.changes).toBe(5);
+      expect(result.meta?.rows_written).toBe(5);
+    });
+  });
+
+  describe('dump', () => {
+    it('should throw error as not supported', async () => {
+      const adapter = new D1RestAdapter(mockOptions);
+
+      await expect(adapter.dump()).rejects.toThrow('dump() is not supported via D1 REST API');
+    });
+  });
+
+  describe('d1RestAdapter factory', () => {
+    it('should create D1RestAdapter instance', () => {
+      const adapter = d1RestAdapter(mockOptions);
+      expect(adapter).toBeInstanceOf(D1RestAdapter);
+    });
+  });
+
+  describe('custom baseUrl', () => {
+    it('should use custom baseUrl when provided', async () => {
+      const customBaseUrl = 'https://api.example.com';
+      const mockResponse = {
+        success: true,
+        result: [{ success: true, meta: {}, results: [{ id: 1 }] }],
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const adapter = new D1RestAdapter({ ...mockOptions, baseUrl: customBaseUrl });
+      (adapter as unknown as { fetch: typeof mockFetch }).fetch = mockFetch;
+
+      const statement = adapter.prepare('SELECT 1');
+      await statement.bind().all();
+
+      // Verify the URL used the custom baseUrl
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[0].toString()).toContain(customBaseUrl);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

实现 D1RestAdapter，实现 SqlClient 接口，支持通过 Cloudflare REST API 访问 D1 数据库。

### 新增文件

- : D1 REST API 适配器
- : 单元测试（13 个用例）

### 功能

| 方法 | 支持 |
|------|------|
| prepare/bind/all/first/run | ✅ |
| batch 批量执行 | ✅ |
| exec 原始 SQL | ✅ |
| dump | ❌ (抛出错误，建议使用 wrangler d1 export) |

### 使用示例



### 统一工厂函数



### Testing

✅ All 280 tests passing (16 test files)

### Related Issue

Fixes #143