### PR TITLE
feat: add platform abstraction layer for multi-platform deployment

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,8 @@
  */
 
 import { CORS_HEADERS } from '../utils/constants';
+import { getPlatformDb } from '../platforms';
+import { createSqlClient } from '../db/factory';
 import type { Env } from '../types';
 
 export interface ApiKeyRecord {
@@ -25,11 +27,32 @@ export function extractApiKey(request: Request): string | null {
   );
 }
 
-export async function authenticate(request: Request, env: Env): Promise<boolean> {
+/**
+ * Authenticate a request using API key from headers
+ *
+ * Uses platform abstraction to access database, supporting both
+ * Cloudflare (env.PLAYBOX_D1) and future platforms (Vercel, etc.)
+ *
+ * @param request - The incoming request
+ * @param env - Optional Cloudflare env (for backward compatibility)
+ * @returns true if valid, false otherwise
+ */
+export async function authenticate(request: Request, env?: Env): Promise<boolean> {
   const apiKey = extractApiKey(request);
   if (!apiKey) return false;
 
-  const db = env.PLAYBOX_D1;
+  // Try platform abstraction first, fall back to env if provided
+  let db = getPlatformDb();
+
+  if (!db && env) {
+    // Backward compatibility: use env.PLAYBOX_D1 directly
+    // Use unknown cast to avoid type conflicts with Env definition
+    const d1 = (env as unknown as { PLAYBOX_D1?: unknown }).PLAYBOX_D1;
+    if (d1) {
+      db = createSqlClient({ d1: d1 as Parameters<typeof createSqlClient>[0]['d1'] });
+    }
+  }
+
   if (!db) return false;
 
   const result = await db.prepare('SELECT * FROM llm_api_keys WHERE api_key = ? AND is_active = 1').bind(apiKey).first();

--- a/src/platforms/AGENTS.md
+++ b/src/platforms/AGENTS.md
@@ -1,0 +1,60 @@
+# Platforms
+
+**Location:** `src/platforms/`
+
+## OVERVIEW
+
+Platform abstraction layer for multi-platform deployment support.
+Provides unified access to platform-specific resources across
+Cloudflare Workers, Vercel, Node.js, and other environments.
+
+## STRUCTURE
+
+```
+platforms/
+├── index.ts    # Main entry point - getPlatformDb(), getPlatformContext()
+└── types.ts    # PlatformContext, PlatformEnv, PlatformType interfaces
+```
+
+## WHERE TO LOOK
+
+| Task                    | Location      | Notes                          |
+|-------------------------|---------------|--------------------------------|
+| Get database client     | `index.ts`    | `getPlatformDb()`              |
+| Platform detection      | `index.ts`    | `detectPlatform()`, `isPlatform()` |
+| Platform types          | `types.ts`    | `PlatformType`, `PlatformContext` |
+
+## USAGE
+
+```typescript
+import { getPlatformDb, getPlatformType } from '@/platforms';
+
+// Get database (null if not available)
+const db = getPlatformDb();
+if (!db) {
+  throw new Error('Database not available on this platform');
+}
+
+// Query database
+const { results } = await db.prepare('SELECT * FROM users').all();
+
+// Check platform
+if (isPlatform('cloudflare')) {
+  // Cloudflare-specific code
+}
+```
+
+## PLATFORM SUPPORT
+
+| Platform     | Database    | Notes                              |
+|--------------|-------------|-----------------------------------|
+| Cloudflare   | D1          | Full support via getCloudflareContext() |
+| Vercel       | PostgreSQL  | Planned (not yet implemented)     |
+| Node.js      | None        | For local development/testing     |
+
+## CONVENTIONS
+
+- **Singleton pattern**: Platform context is cached at module level
+- **Lazy initialization**: Context is created on first access
+- **Graceful degradation**: Returns null for unavailable resources
+- **Test helpers**: `resetPlatformContext()`, `setPlatformContext()` for testing

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -1,0 +1,234 @@
+/**
+ * Platform abstraction layer implementation
+ *
+ * Provides a unified interface for accessing platform resources
+ * across different deployment targets.
+ *
+ * Usage:
+ *   import { getPlatformDb } from '@/platforms';
+ *   const db = getPlatformDb();
+ */
+
+import { createSqlClient } from '../db/factory';
+import type { PlatformContext, PlatformEnv, PlatformType } from './types';
+
+// Module-level singleton
+let _context: PlatformContext | null = null;
+let _platformDetected: PlatformType | null = null;
+
+/**
+ * Detect current platform type
+ */
+function detectPlatform(): PlatformType {
+  // Check Cloudflare Workers
+  const globalAny = globalThis as Record<string, unknown>;
+  if (globalAny.__ENV !== undefined || process.env.CF_PAGES === 'true') {
+    return 'cloudflare';
+  }
+
+  // Check Vercel
+  if (process.env.VERCEL === 'true' || process.env.VERCEL_ENV) {
+    return 'vercel';
+  }
+
+  // Check Node.js
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    return 'nodejs';
+  }
+
+  return 'other';
+}
+
+/**
+ * Create Cloudflare platform context
+ * Uses getCloudflareContext() from @opennextjs/cloudflare
+ */
+function createCloudflareContext(): PlatformContext {
+  // Lazy import to avoid issues on non-CF platforms
+  let getCloudflareContext: () => { env: unknown; ctx: unknown };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const module = require('@opennextjs/cloudflare');
+    getCloudflareContext = module.getCloudflareContext;
+  } catch {
+    // Not on Cloudflare, will fall through to mock context
+    return createMockContext();
+  }
+
+  return {
+    getDatabase: () => {
+      try {
+        const raw = getCloudflareContext();
+        const env = raw.env as { PLAYBOX_D1?: unknown };
+        if (!env.PLAYBOX_D1) return null;
+        return createSqlClient({ d1: env.PLAYBOX_D1 as Parameters<typeof createSqlClient>[0]['d1'] });
+      } catch {
+        return null;
+      }
+    },
+
+    getPlatformType: () => 'cloudflare',
+
+    isPlatform: (platform: PlatformType) => platform === 'cloudflare',
+
+    getEnv: () => {
+      try {
+        const raw = getCloudflareContext();
+        const env = raw.env as { PLAYBOX_D1?: unknown; AUTH_TOKEN?: string };
+        return {
+          platformType: 'cloudflare' as PlatformType,
+          primaryDb: env.PLAYBOX_D1
+            ? createSqlClient({ d1: env.PLAYBOX_D1 as Parameters<typeof createSqlClient>[0]['d1'] })
+            : null,
+          authToken: env.AUTH_TOKEN,
+        };
+      } catch {
+        return { platformType: 'cloudflare', primaryDb: null };
+      }
+    },
+
+    getExecutionContext: () => {
+      try {
+        const raw = getCloudflareContext();
+        return raw.ctx as { waitUntil(promise: Promise<unknown>): void; passThroughOnException(): void } | undefined;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+/**
+ * Create Vercel platform context
+ * Uses environment variables
+ */
+function createVercelContext(): PlatformContext {
+  return {
+    getDatabase: () => {
+      // For Vercel, use DATABASE_URL if available
+      const dbUrl = process.env.DATABASE_URL;
+      if (!dbUrl) return null;
+
+      // TODO: Implement PostgreSQL adapter for Vercel
+      // For now, return null to maintain backward compatibility
+      console.warn('Vercel database support not yet implemented');
+      return null;
+    },
+
+    getPlatformType: () => 'vercel',
+
+    isPlatform: (platform: PlatformType) => platform === 'vercel',
+
+    getEnv: (): PlatformEnv => ({
+      platformType: 'vercel',
+      primaryDb: null,
+      authToken: process.env.AUTH_TOKEN,
+    }),
+  };
+}
+
+/**
+ * Create a mock context for Node.js / local development
+ */
+function createMockContext(): PlatformContext {
+  return {
+    getDatabase: () => null,
+
+    getPlatformType: () => 'nodejs',
+
+    isPlatform: (platform: PlatformType) => platform === 'nodejs',
+
+    getEnv: (): PlatformEnv => ({
+      platformType: 'nodejs',
+      primaryDb: null,
+      authToken: process.env.AUTH_TOKEN,
+    }),
+  };
+}
+
+/**
+ * Initialize platform context based on detected platform
+ */
+function initPlatformContext(): PlatformContext {
+  const platform = detectPlatform();
+  _platformDetected = platform;
+
+  switch (platform) {
+    case 'cloudflare':
+      return createCloudflareContext();
+    case 'vercel':
+      return createVercelContext();
+    default:
+      return createMockContext();
+  }
+}
+
+/**
+ * Get or create the platform context singleton
+ */
+function getContext(): PlatformContext {
+  if (!_context) {
+    _context = initPlatformContext();
+  }
+  return _context;
+}
+
+/**
+ * Get the primary database client
+ * Returns null if no database is available
+ *
+ * Usage:
+ *   const db = getPlatformDb();
+ *   if (!db) throw new Error('Database not available');
+ *   const { results } = await db.prepare('SELECT * FROM users').all();
+ */
+export function getPlatformDb(): import('../db/types').SqlClient | null {
+  return getContext().getDatabase();
+}
+
+/**
+ * Get the current platform type
+ */
+export function getPlatformType(): PlatformType {
+  if (_platformDetected) return _platformDetected;
+  return getContext().getPlatformType();
+}
+
+/**
+ * Check if running on a specific platform
+ */
+export function isPlatform(platform: PlatformType): boolean {
+  return getContext().isPlatform(platform);
+}
+
+/**
+ * Get the platform environment
+ */
+export function getPlatformEnv(): PlatformEnv {
+  return getContext().getEnv();
+}
+
+/**
+ * Get the full platform context
+ */
+export function getPlatformContext(): PlatformContext {
+  return getContext();
+}
+
+/**
+ * Reset platform context (for testing)
+ */
+export function resetPlatformContext(): void {
+  _context = null;
+  _platformDetected = null;
+}
+
+/**
+ * Set custom platform context (for testing)
+ */
+export function setPlatformContext(context: PlatformContext): void {
+  _context = context;
+}
+
+// Re-export types
+export type { PlatformContext, PlatformEnv, PlatformType } from './types';

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Platform abstraction layer types
+ *
+ * Provides a unified interface for accessing platform-specific resources
+ * across different deployment targets (Cloudflare, Vercel, Node.js, etc.)
+ */
+
+import type { SqlClient } from '../db/types';
+
+/** Supported platform types */
+export type PlatformType = 'cloudflare' | 'vercel' | 'nodejs' | 'other';
+
+/**
+ * Platform environment interface
+ * Abstracts platform-specific environment variables and bindings
+ */
+export interface PlatformEnv {
+  /** Platform type identifier */
+  platformType: PlatformType;
+
+  /** Primary database connection */
+  primaryDb: SqlClient | null;
+
+  /** AUTH_TOKEN for API key validation */
+  authToken?: string;
+}
+
+/**
+ * Platform context interface
+ * Provides runtime access to platform resources
+ */
+export interface PlatformContext {
+  /**
+   * Get the primary database client
+   * Returns null if no database is available on this platform
+   */
+  getDatabase(): SqlClient | null;
+
+  /**
+   * Get the current platform type
+   */
+  getPlatformType(): PlatformType;
+
+  /**
+   * Check if running on a specific platform
+   */
+  isPlatform(platform: PlatformType): boolean;
+
+  /**
+   * Get the platform environment
+   */
+  getEnv(): PlatformEnv;
+
+  /**
+   * Optional execution context (Cloudflare only)
+   * Uses compatible interface from src/protocols/types.ts
+   */
+  getExecutionContext?(): {
+    waitUntil(promise: Promise<unknown>): void;
+    passThroughOnException(): void;
+  } | undefined;
+}

--- a/test/unit/platforms/index.test.ts
+++ b/test/unit/platforms/index.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for platform abstraction layer
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getPlatformType,
+  isPlatform,
+  getPlatformEnv,
+  resetPlatformContext,
+  setPlatformContext,
+} from '../../../src/platforms';
+import type { PlatformContext, PlatformType } from '../../../src/platforms/types';
+
+describe('Platform Abstraction', () => {
+  beforeEach(() => {
+    // Reset singleton before each test
+    resetPlatformContext();
+  });
+
+  afterEach(() => {
+    resetPlatformContext();
+  });
+
+  describe('getPlatformType', () => {
+    it('should return nodejs in test environment', () => {
+      const platform = getPlatformType();
+      expect(['nodejs', 'cloudflare', 'vercel', 'other']).toContain(platform);
+    });
+  });
+
+  describe('isPlatform', () => {
+    it('should return true for current platform', () => {
+      const currentPlatform = getPlatformType();
+      expect(isPlatform(currentPlatform)).toBe(true);
+    });
+
+    it('should return false for other platforms', () => {
+      const currentPlatform = getPlatformType();
+      const otherPlatforms: PlatformType[] = ['cloudflare', 'vercel', 'nodejs', 'other'].filter(
+        (p) => p !== currentPlatform
+      ) as PlatformType[];
+
+      (otherPlatforms as PlatformType[]).forEach((platform) => {
+        expect(isPlatform(platform)).toBe(false);
+      });
+    });
+  });
+
+  describe('getPlatformEnv', () => {
+    it('should return platform environment', () => {
+      const env = getPlatformEnv();
+      expect(env).toHaveProperty('platformType');
+      expect(['cloudflare', 'vercel', 'nodejs', 'other']).toContain(env.platformType);
+    });
+
+    it('should include primaryDb (may be null)', () => {
+      const env = getPlatformEnv();
+      expect('primaryDb' in env).toBe(true);
+    });
+  });
+
+  describe('setPlatformContext', () => {
+    it('should allow custom platform context', () => {
+      const customContext: PlatformContext = {
+        getDatabase: () => null,
+        getPlatformType: () => 'vercel',
+        isPlatform: (p) => p === 'vercel',
+        getEnv: () => ({
+          platformType: 'vercel',
+          primaryDb: null,
+          authToken: 'test-token',
+        }),
+      };
+
+      setPlatformContext(customContext);
+
+      expect(getPlatformType()).toBe('vercel');
+      expect(isPlatform('vercel')).toBe(true);
+      expect(getPlatformEnv().authToken).toBe('test-token');
+    });
+
+    it('should override default context', () => {
+      const customContext: PlatformContext = {
+        getDatabase: () => null,
+        getPlatformType: () => 'cloudflare',
+        isPlatform: (p) => p === 'cloudflare',
+        getEnv: () => ({
+          platformType: 'cloudflare',
+          primaryDb: null,
+          authToken: 'cf-token',
+        }),
+      };
+
+      setPlatformContext(customContext);
+
+      expect(getPlatformType()).toBe('cloudflare');
+      expect(isPlatform('cloudflare')).toBe(true);
+    });
+  });
+
+  describe('resetPlatformContext', () => {
+    it('should reset context when called', () => {
+      const customContext: PlatformContext = {
+        getDatabase: () => null,
+        getPlatformType: () => 'other',
+        isPlatform: () => false,
+        getEnv: () => ({
+          platformType: 'other',
+          primaryDb: null,
+        }),
+      };
+
+      setPlatformContext(customContext);
+      expect(getPlatformType()).toBe('other');
+
+      resetPlatformContext();
+      // After reset, should use default platform detection
+      expect(['nodejs', 'cloudflare', 'vercel', 'other']).toContain(getPlatformType());
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add platform abstraction layer to support deployment on both Cloudflare Workers and Vercel.

### Changes

1. **New Platform Abstraction Layer** ()
   - : Define , ,  interfaces
   - : Implement , ,  functions

2. **Platform Detection**
   - Cloudflare Workers: uses  via lazy import
   - Vercel: placeholder for future PostgreSQL support
   - Node.js: mock context for local dev/testing

3. **Refactored **
   - Uses  instead of direct  access
   - Maintains backward compatibility with existing env-based calls

4. **Unit Tests**
   - Added  (8 tests)

### Usage



### Testing

- ✅ 
> playbox@0.0.0 build
> npx wrangler types && next build


 ⛅️ wrangler 4.84.1
───────────────────
Generating project types...

declare namespace Cloudflare {
	interface Env {
		PLAYBOX_D1: D1Database;
		ASSETS: Fetcher;
	}
}
interface Env extends Cloudflare.Env {}

Generating runtime types...

Runtime types generated.


✨ Types written to worker-configuration.d.ts

📖 Read about runtime types
https://developers.cloudflare.com/workers/languages/typescript/#generate-types
📣 Remember to rerun 'wrangler types' after you change your wrangler.jsonc file.

   ▲ Next.js 15.5.15

   Creating an optimized production build ...
 ✓ Compiled successfully in 3.4s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/8) ...
   Generating static pages (2/8) 
   Generating static pages (4/8) 
   Generating static pages (6/8) 
 ✓ Generating static pages (8/8)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                    Size  First Load JS
┌ ○ /_not-found                             1.04 kB         104 kB
├ ○ /admin                                  7.14 kB         234 kB
├ ○ /admin/domains                          5.66 kB         336 kB
├ ○ /admin/github-gists                     26.3 kB         393 kB
├ ○ /admin/llm-keys                         3.17 kB         361 kB
├ ○ /admin/providers                        2.83 kB         170 kB
├ ƒ /api/admin/domains                        189 B         103 kB
├ ƒ /api/admin/github-gists                   189 B         103 kB
├ ƒ /api/admin/github-gists/[id]              189 B         103 kB
├ ƒ /api/admin/llm-keys                       189 B         103 kB
├ ƒ /api/admin/llm-keys/[id]                  189 B         103 kB
├ ƒ /api/admin/providers                      189 B         103 kB
├ ƒ /api/admin/providers/[id]                 189 B         103 kB
├ ƒ /api/admin/providers/models               189 B         103 kB
├ ƒ /api/admin/providers/models/[provider]    189 B         103 kB
├ ƒ /api/admin/providers/speed-test           189 B         103 kB
├ ƒ /api/admin/tables                         189 B         103 kB
├ ƒ /api/admin/tables/[table]/batch           189 B         103 kB
├ ƒ /api/admin/tables/[table]/rows            189 B         103 kB
├ ƒ /api/admin/tables/[table]/rows/[rowid]    189 B         103 kB
├ ƒ /v1/chat/completions                      189 B         103 kB
├ ƒ /v1/embeddings                            189 B         103 kB
├ ƒ /v1/messages                              189 B         103 kB
├ ƒ /v1/models                                189 B         103 kB
├ ƒ /v1/rerank                                189 B         103 kB
├ ƒ /v1beta/models                            189 B         103 kB
└ ƒ /v1beta/models/[...action]                189 B         103 kB
+ First Load JS shared by all                103 kB
  ├ chunks/1255-c689bccdcaaca5b4.js         45.7 kB
  ├ chunks/4bd1b696-16dcc2bec6e1bff8.js     54.3 kB
  └ other shared chunks (total)             2.62 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand passes
- ✅ 
> playbox@0.0.0 test
> vitest


 RUN  v3.2.4 /home/agent/workspace/playbox-multi-platform

[vpw:debug] Adding `enable_nodejs_tty_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_fs_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_http_modules` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_perf_hooks_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:info] Starting isolated runtimes for vitest.config.mts...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
 ✓ test/unit/managers/key.test.ts (7 tests) 455ms
 ✓ test/unit/protocols/openai.test.ts (8 tests) 359ms
 ✓ test/unit/lib/cloudflare-context.test.ts (9 tests) 454ms
 ✓ test/unit/managers/auth.test.ts (14 tests) 541ms
 ✓ test/unit/config/index.test.ts (11 tests) 568ms
 ✓ test/unit/utils/constants.test.ts (15 tests) 632ms
 ✓ test/unit/platforms/index.test.ts (8 tests) 541ms
 ✓ test/unit/protocols/google.test.ts (10 tests) 567ms
 ✓ test/unit/utils/logger.test.ts (15 tests) 660ms
 ✓ test/unit/db/d1-rest-adapter.test.ts (13 tests) 708ms
 ✓ test/unit/lib/middleware.test.ts (16 tests) 682ms
 ✓ test/unit/lib/auth.test.ts (16 tests) 606ms
 ✓ test/unit/utils/sse-parser.test.ts (22 tests) 828ms
 ✓ test/unit/lib/response-helpers.test.ts (25 tests) 826ms
 ✓ test/unit/protocols/index.test.ts (11 tests) 189ms
 ✓ test/unit/protocols/anthropic.test.ts (28 tests) 775ms
 ✓ test/unit/utils/ssrf-protection.test.ts (60 tests) 1008ms

 Test Files  17 passed (17)
      Tests  288 passed (288)
   Start at  08:00:27
   Duration  3.61s (transform 581ms, setup 748ms, collect 2.74s, tests 10.40s, environment 1ms, prepare 5.67s)

[vpw:debug] Shutting down runtimes...
[vpw:debug] Disposing remote proxy sessions... passes (288 tests, 17 test files)

Closes #145