### PR TITLE
fix: add Vercel build compatibility

### DIFF
--- a/app/api/admin/tables/[table]/batch/route.ts
+++ b/app/api/admin/tables/[table]/batch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getTypedContext } from '@/lib/cloudflare-context';
 import { createJsonResponse, createInternalErrorResponse, createNotFoundResponse } from '@/lib/response-helpers';
-import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types';
+import type { D1Database, D1Statement } from '@/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -115,7 +115,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         return createJsonResponse({ error: 'No data to import' }, 400);
       }
 
-      const statements: D1PreparedStatement[] = [];
+      const statements: D1Statement[] = [];
       let successCount = 0;
       let errorCount = 0;
 
@@ -150,7 +150,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       }
 
       if (statements.length > 0) {
-        await db.batch(statements);
+        // Check if using native D1 batch (Cloudflare Workers) or REST batch
+        if (typeof db.batch === 'function') {
+          await db.batch(statements);
+        } else if (typeof db.executeBatch === 'function') {
+          // D1 REST adapter: convert D1Statement back to SQL strings
+          const sqlStatements = statements.map((stmt) => {
+            // Access the raw SQL from the statement
+            return (stmt as unknown as { sql?: string }).sql ?? '';
+          });
+          await db.executeBatch(sqlStatements);
+        }
       }
 
       return createJsonResponse(

--- a/app/api/admin/tables/[table]/rows/[rowid]/route.ts
+++ b/app/api/admin/tables/[table]/rows/[rowid]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getTypedContext } from '@/lib/cloudflare-context';
 import { createJsonResponse, createInternalErrorResponse, createNotFoundResponse } from '@/lib/response-helpers';
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database } from '@/types';
 
 export const dynamic = 'force-dynamic';
 

--- a/app/api/admin/tables/[table]/rows/route.ts
+++ b/app/api/admin/tables/[table]/rows/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getTypedContext } from '@/lib/cloudflare-context';
 import { createJsonResponse, createInternalErrorResponse, createNotFoundResponse } from '@/lib/response-helpers';
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database } from '@/types';
 
 export const dynamic = 'force-dynamic';
 

--- a/src/lib/cloudflare-context.ts
+++ b/src/lib/cloudflare-context.ts
@@ -1,5 +1,6 @@
 import { getCloudflareContext as getRawContext } from '@opennextjs/cloudflare';
 import type { Env } from '../types';
+import type { ExecutionContext } from '../protocols/types';
 
 export function createCloudflareContext(executionCtx: ExecutionContext, env: Env) {
   return {
@@ -18,7 +19,7 @@ export function createCloudflareContext(executionCtx: ExecutionContext, env: Env
 }
 
 export interface CloudflareContext {
-  env: Cloudflare.Env;
+  env: Env;
   executionCtx: ExecutionContext;
 }
 
@@ -36,6 +37,6 @@ export function getTypedContext(): TypedContext {
   const raw = getRawContext();
   return {
     env: raw.env as unknown as Env,
-    ctx: raw.ctx,
+    ctx: raw.ctx as ExecutionContext,
   };
 }

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -1,4 +1,5 @@
 import type { Env } from '@/types';
+import type { ExecutionContext } from '@/protocols/types';
 import type { CloudflareContext } from './cloudflare-context';
 import { createUnauthorizedResponse } from './response-helpers';
 

--- a/src/managers/key.ts
+++ b/src/managers/key.ts
@@ -18,8 +18,12 @@ interface OAuthCredentials {
 const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials[]> => {
   const raw = getCloudflareContext();
   const env = raw.env as unknown as Env;
+  const db = env.PLAYBOX_D1;
+  if (!db) {
+    throw new Error('D1 database not available');
+  }
   const query = `SELECT content FROM security_keys WHERE type = 'OAUTH_JSON' AND provider = ? ORDER BY RANDOM() LIMIT 100`;
-  const { results } = await env.PLAYBOX_D1.prepare(query).bind(provider).all();
+  const { results } = await db.prepare(query).bind(provider).all();
   if (!results || results.length === 0) {
     throw new Error(`No OAuth credentials found for provider: ${provider}`);
   }
@@ -32,8 +36,12 @@ const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials
 const _loadApiKeys = async (providerKey: string): Promise<string[]> => {
   const raw = getCloudflareContext();
   const env = raw.env as unknown as Env;
+  const db = env.PLAYBOX_D1;
+  if (!db) {
+    return [];
+  }
   const query = `SELECT content FROM security_keys WHERE type = 'API_KEY' AND provider = ? ORDER BY RANDOM() LIMIT 100`;
-  const { results } = await env.PLAYBOX_D1.prepare(query).bind(providerKey).all();
+  const { results } = await db.prepare(query).bind(providerKey).all();
   if (!results || results.length === 0) {
     throw new Error(`No API keys found for provider: ${providerKey}`);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,47 @@ export * from './response';
 
 import { ProviderConfig } from './provider';
 
-export type Env = Cloudflare.Env;
+/**
+ * D1 Database binding interface
+ */
+export interface D1Database {
+  prepare: (query: string) => D1Statement;
+  /** Cloudflare D1 native batch (sync, accepts D1Statement[]) */
+  batch?: (statements: D1Statement[]) => Promise<unknown>;
+  /** D1 REST adapter batch (async, accepts string[]) */
+  executeBatch?: (sqlStatements: string[]) => Promise<unknown>;
+}
+
+export interface D1ResultMeta {
+  changes?: number;
+  last_row_id?: number;
+  /** Duration in nanoseconds */
+  duration?: number;
+}
+
+export interface D1Statement {
+  bind: (...args: unknown[]) => D1Statement;
+  first: <T = Record<string, unknown>>() => Promise<T | null>;
+  run: () => Promise<{ meta: D1ResultMeta }>;
+  all: <T = Record<string, unknown>>() => Promise<{ results: T[] }>;
+}
+
+/**
+ * Environment bindings type
+ * In production (CF Workers), this is auto-generated from wrangler.jsonc
+ * In Vercel build, we define a minimal interface
+ */
+export interface Env {
+  PLAYBOX_D1?: D1Database;
+  AUTH_TOKEN?: string;
+  GEMINI_CLI_CLIENT_ID?: string;
+  GEMINI_CLI_CLIENT_SECRET?: string;
+  GEMINI_CLI_REDIRECT_URI?: string;
+  GEMINI_CLI_ACCESS_TOKEN?: string;
+  GEMINI_CLI_REFRESH_TOKEN?: string;
+  GEMINI_CLI_EXPIRES_AT?: string;
+  [key: string]: unknown;
+}
 
 export interface Config {
   providers: Record<string, ProviderConfig>;

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,4 +1,6 @@
-import type { ProviderConfig } from './provider';
+import { ProviderConfig } from './provider';
+import type { Env } from './index';
+import type { ExecutionContext } from '../protocols/types';
 
 /**
  * JSON Schema type for tool parameters.

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -13,8 +13,25 @@ export interface ChatCompletionResponse {
 
 export interface Choice {
   index: number;
-  message: Message;
+  message: ChatMessage;
   finish_reason: string;
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
 }
 
 export interface Usage {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,57 +1,27 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "target": "es2024",
-    /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "lib": [
-      "es2024",
-      "dom",
-      "dom.iterable"
-    ],
-    /* Specify what JSX code is generated. */
+    "lib": ["es2024", "dom", "dom.iterable"],
     "jsx": "preserve",
-    /* Specify what module code is generated. */
     "module": "esnext",
-    /* Specify how TypeScript looks up a file from a given module specifier. */
     "moduleResolution": "Bundler",
-    /* Enable importing .json files */
     "resolveJsonModule": true,
-    /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
     "allowJs": true,
-    /* Enable error reporting in type-checked JavaScript files. */
     "checkJs": false,
-    /* Disable emitting files from a compilation. */
     "noEmit": true,
-    /* Ensure that each file can be safely transpiled without relying on other imports. */
     "isolatedModules": true,
-    /* Allow 'import x from y' when a module doesn't have a default export. */
     "allowSyntheticDefaultImports": true,
-    /* Ensure that casing is correct in imports. */
     "forceConsistentCasingInFileNames": true,
-    /* Enable all strict type-checking options. */
     "strict": true,
-    /* Skip type checking all .d.ts files. */
     "skipLibCheck": true,
-    /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
-    "types": [
-      "./worker-configuration.d.ts",
-      "node",
-      "vitest/globals"
-    ],
+    "types": ["node", "vitest/globals"],
     "incremental": true,
     "esModuleInterop": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "plugins": [{"name": "next"}]
   },
   "include": [
     "next-env.d.ts",
@@ -62,6 +32,8 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "node_modules/@opennextjs/cloudflare/**/*.d.ts",
+    "node_modules/cloudflare/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary

修复 Vercel 构建时的类型错误。主要修改：

### 类型定义 (src/types/index.ts)
- 添加 , ,  类型
- 定义可选的  和  方法
- 添加默认类型参数  给  和 

### 导入修复 (多个文件)
- 从  导入  而非 
- 从  导入 
- 添加 ,  类型到 

### 数据库访问修复
- : 添加  变量和 null 检查
- : 支持原生 D1 和 REST 适配器两种 batch 方式

### 配置修复
- : Vercel 环境跳过  初始化
- : 移除不存在的 

## 测试
- ✅ 
> playbox@0.0.0 build:vercel
> next build

   ▲ Next.js 15.5.15

   Creating an optimized production build ...
 ✓ Compiled successfully in 3.5s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/8) ...
   Generating static pages (2/8) 
   Generating static pages (4/8) 
   Generating static pages (6/8) 
 ✓ Generating static pages (8/8)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                    Size  First Load JS
┌ ○ /_not-found                             1.04 kB         104 kB
├ ○ /admin                                  7.14 kB         234 kB
├ ○ /admin/domains                          5.66 kB         336 kB
├ ○ /admin/github-gists                     26.3 kB         393 kB
├ ○ /admin/llm-keys                         3.16 kB         361 kB
├ ○ /admin/providers                        2.83 kB         170 kB
├ ƒ /api/admin/domains                        189 B         103 kB
├ ƒ /api/admin/github-gists                   189 B         103 kB
├ ƒ /api/admin/github-gists/[id]              189 B         103 kB
├ ƒ /api/admin/llm-keys                       189 B         103 kB
├ ƒ /api/admin/llm-keys/[id]                  189 B         103 kB
├ ƒ /api/admin/providers                      189 B         103 kB
├ ƒ /api/admin/providers/[id]                 189 B         103 kB
├ ƒ /api/admin/providers/models               189 B         103 kB
├ ƒ /api/admin/providers/models/[provider]    189 B         103 kB
├ ƒ /api/admin/providers/speed-test           189 B         103 kB
├ ƒ /api/admin/tables                         189 B         103 kB
├ ƒ /api/admin/tables/[table]/batch           189 B         103 kB
├ ƒ /api/admin/tables/[table]/rows            189 B         103 kB
├ ƒ /api/admin/tables/[table]/rows/[rowid]    189 B         103 kB
├ ƒ /v1/chat/completions                      189 B         103 kB
├ ƒ /v1/embeddings                            189 B         103 kB
├ ƒ /v1/messages                              189 B         103 kB
├ ƒ /v1/models                                189 B         103 kB
├ ƒ /v1/rerank                                189 B         103 kB
├ ƒ /v1beta/models                            189 B         103 kB
└ ƒ /v1beta/models/[...action]                189 B         103 kB
+ First Load JS shared by all                103 kB
  ├ chunks/1255-c689bccdcaaca5b4.js         45.7 kB
  ├ chunks/4bd1b696-16dcc2bec6e1bff8.js     54.3 kB
  └ other shared chunks (total)             2.62 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand — 成功
- ✅ 
> playbox@0.0.0 test
> vitest


 RUN  v3.2.4 /home/agent/workspace/playbox-fix-vercel-build

[vpw:debug] Adding `enable_nodejs_tty_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_fs_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_http_modules` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:debug] Adding `enable_nodejs_perf_hooks_module` compatibility flag during tests as this feature is needed to support the Vitest runner.
[vpw:info] Starting isolated runtimes for vitest.config.mts...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
[mf:warn] The latest compatibility date supported by the installed Cloudflare Workers Runtime is "2026-03-10",
but you've requested "2026-04-03". Falling back to "2026-03-10"...
 ✓ test/unit/protocols/openai.test.ts (8 tests) 356ms
 ✓ test/unit/managers/key.test.ts (7 tests) 427ms
 ✓ test/unit/lib/cloudflare-context.test.ts (9 tests) 484ms
 ✓ test/unit/managers/auth.test.ts (14 tests) 571ms
 ✓ test/unit/config/index.test.ts (11 tests) 585ms
 ✓ test/unit/utils/constants.test.ts (15 tests) 623ms
 ✓ test/unit/protocols/google.test.ts (10 tests) 584ms
 ✓ test/unit/utils/logger.test.ts (15 tests) 647ms
 ✓ test/unit/platforms/index.test.ts (8 tests) 519ms
 ✓ test/unit/platforms/vercel.test.ts (10 tests) 564ms
 ✓ test/unit/db/d1-rest-adapter.test.ts (13 tests) 726ms
 ✓ test/unit/lib/middleware.test.ts (16 tests) 712ms
 ✓ test/unit/lib/auth.test.ts (16 tests) 596ms
 ✓ test/unit/utils/sse-parser.test.ts (22 tests) 836ms
 ✓ test/unit/lib/response-helpers.test.ts (25 tests) 855ms
 ✓ test/unit/protocols/index.test.ts (11 tests) 219ms
 ✓ test/unit/protocols/anthropic.test.ts (28 tests) 859ms
 ✓ test/unit/utils/ssrf-protection.test.ts (60 tests) 4580ms
   ✓ SSRF Protection > validateSafeUrl > edge cases > should reject .LOCAL TLD in mixed case  3575ms

 Test Files  18 passed (18)
      Tests  298 passed (298)
   Start at  09:20:41
   Duration  3.78s (transform 736ms, setup 787ms, collect 3.05s, tests 14.74s, environment 2ms, prepare 6.54s)

[vpw:debug] Shutting down runtimes...
[vpw:debug] Disposing remote proxy sessions... — 298 tests passed