### PR TITLE
fix: remove getCloudflareContext calls for Vercel compatibility

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -1,21 +1,20 @@
 import { Provider, ProviderConfig } from '../types/provider';
-import type { Env } from '../types';
+import type { SqlClient } from '../db/types';
 import { unstable_cache } from 'next/cache';
 import { revalidateTag } from 'next/cache';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPlatformDb } from '../platforms';
 
 export interface Config {
   providers: Provider;
   default_provider: string;
 }
 
-async function loadProvidersFromD1(env: Env): Promise<Config | null> {
-  const db = env.PLAYBOX_D1;
-  if (!db) return null;
+async function loadProvidersFromD1(db: SqlClient): Promise<Config | null> {
 
   try {
     const { results } = await db
       .prepare('SELECT name, type, family, endpoint, key, models, auth_type FROM providers WHERE enabled = 1 ORDER BY sort_order ASC')
+      .bind()
       .all();
 
     if (!results || results.length === 0) {
@@ -56,9 +55,9 @@ async function loadProvidersFromD1(env: Env): Promise<Config | null> {
 }
 
 const _loadConfigFromD1 = async (): Promise<Config | null> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  return loadProvidersFromD1(env);
+  const db = getPlatformDb();
+  if (!db) return null;
+  return loadProvidersFromD1(db);
 };
 
 export const getDefaultConfigCached = unstable_cache(

--- a/src/managers/key.ts
+++ b/src/managers/key.ts
@@ -1,6 +1,5 @@
-import type { Env } from '../types';
 import { unstable_cache } from 'next/cache';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPlatformDb } from '../platforms';
 
 interface Provider {
   key: string;
@@ -16,9 +15,7 @@ interface OAuthCredentials {
 }
 
 const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials[]> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  const db = env.PLAYBOX_D1;
+  const db = getPlatformDb();
   if (!db) {
     throw new Error('D1 database not available');
   }
@@ -34,9 +31,7 @@ const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials
 };
 
 const _loadApiKeys = async (providerKey: string): Promise<string[]> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  const db = env.PLAYBOX_D1;
+  const db = getPlatformDb();
   if (!db) {
     return [];
   }


### PR DESCRIPTION
## Summary

Fix Vercel runtime error by replacing direct `getCloudflareContext()` calls with `getPlatformDb()`:

### Files Changed

- **src/managers/key.ts**: `_loadOAuthCredentials`, `_loadApiKeys`
- **src/config/default.ts**: `_loadConfigFromD1`, `loadProvidersFromD1`

### Changes

1. Replace `getCloudflareContext()` with `getPlatformDb()`
2. Change `loadProvidersFromD1(env: Env)` to `loadProvidersFromD1(db: SqlClient)`
3. Add `.bind()` call for queries without parameters

### Testing
- ✅ `npm run build:vercel` passes
- ✅ `npm test` - 298 tests passed