### PR TITLE
fix: remove getCloudflareContext calls for Vercel compatibility

### DIFF
--- a/app/api/admin/providers/models/[provider]/route.ts
+++ b/app/api/admin/providers/models/[provider]/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest } from 'next/server';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { createJsonResponse, createInternalErrorResponse } from '@/lib/response-helpers';
 import { getConfig } from '@/config';
 import { KeyManager } from '@/managers/key';
-import type { Env } from '@/types';
 import type { ProviderConfig } from '@/types/provider';
 
 export const dynamic = 'force-dynamic';
@@ -52,8 +50,6 @@ async function fetchGeminiModels(baseUrl: string, apiKey: string): Promise<Model
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ provider: string }> }) {
   try {
     const { provider: providerName } = await params;
-    const { env: _env } = getCloudflareContext();
-    const _unusedEnv = _env as unknown as Env;
     const config = await getConfig();
 
     const provider = config.providers[providerName] as ProviderConfig | undefined;

--- a/app/api/admin/providers/speed-test/route.ts
+++ b/app/api/admin/providers/speed-test/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest } from 'next/server';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { createJsonResponse, createInternalErrorResponse } from '@/lib/response-helpers';
 import { getConfig } from '@/config';
 import { KeyManager } from '@/managers/key';
-import type { Env } from '@/types';
 import type { ProviderConfig } from '@/types/provider';
 
 export const dynamic = 'force-dynamic';
@@ -79,8 +77,6 @@ function buildGeminiRequest(model: string, endpoint: string, apiKey: string): Re
 
 export async function POST(request: NextRequest) {
   try {
-    const { env: _env } = getCloudflareContext();
-    const _unusedEnv = _env as unknown as Env;
     const config = await getConfig();
 
     const body = (await request.json()) as SpeedTestRequest;

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -1,21 +1,20 @@
 import { Provider, ProviderConfig } from '../types/provider';
-import type { Env } from '../types';
+import type { SqlClient } from '../db/types';
 import { unstable_cache } from 'next/cache';
 import { revalidateTag } from 'next/cache';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPlatformDb } from '../platforms';
 
 export interface Config {
   providers: Provider;
   default_provider: string;
 }
 
-async function loadProvidersFromD1(env: Env): Promise<Config | null> {
-  const db = env.PLAYBOX_D1;
-  if (!db) return null;
+async function loadProvidersFromD1(db: SqlClient): Promise<Config | null> {
 
   try {
     const { results } = await db
       .prepare('SELECT name, type, family, endpoint, key, models, auth_type FROM providers WHERE enabled = 1 ORDER BY sort_order ASC')
+      .bind()
       .all();
 
     if (!results || results.length === 0) {
@@ -56,9 +55,9 @@ async function loadProvidersFromD1(env: Env): Promise<Config | null> {
 }
 
 const _loadConfigFromD1 = async (): Promise<Config | null> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  return loadProvidersFromD1(env);
+  const db = getPlatformDb();
+  if (!db) return null;
+  return loadProvidersFromD1(db);
 };
 
 export const getDefaultConfigCached = unstable_cache(

--- a/src/managers/key.ts
+++ b/src/managers/key.ts
@@ -1,6 +1,5 @@
-import type { Env } from '../types';
 import { unstable_cache } from 'next/cache';
-import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { getPlatformDb } from '../platforms';
 
 interface Provider {
   key: string;
@@ -16,9 +15,7 @@ interface OAuthCredentials {
 }
 
 const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials[]> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  const db = env.PLAYBOX_D1;
+  const db = getPlatformDb();
   if (!db) {
     throw new Error('D1 database not available');
   }
@@ -34,9 +31,7 @@ const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials
 };
 
 const _loadApiKeys = async (providerKey: string): Promise<string[]> => {
-  const raw = getCloudflareContext();
-  const env = raw.env as unknown as Env;
-  const db = env.PLAYBOX_D1;
+  const db = getPlatformDb();
   if (!db) {
     return [];
   }

--- a/src/managers/key.ts
+++ b/src/managers/key.ts
@@ -33,10 +33,13 @@ const _loadOAuthCredentials = async (provider: string): Promise<OAuthCredentials
 const _loadApiKeys = async (providerKey: string): Promise<string[]> => {
   const db = getPlatformDb();
   if (!db) {
+    console.warn('[KeyManager] D1 database not available');
     return [];
   }
   const query = `SELECT content FROM security_keys WHERE type = 'API_KEY' AND provider = ? ORDER BY RANDOM() LIMIT 100`;
+  console.log('[KeyManager] Query:', query, 'Provider:', providerKey);
   const { results } = await db.prepare(query).bind(providerKey).all();
+  console.log('[KeyManager] Results count:', results?.length ?? 0);
   if (!results || results.length === 0) {
     throw new Error(`No API keys found for provider: ${providerKey}`);
   }


### PR DESCRIPTION
## Summary

Remove all direct `getCloudflareContext()` calls to fix Vercel deployment runtime errors.

### Changes

**src/managers/key.ts**
- Replace `getCloudflareContext()` with `getPlatformDb()`
- `_loadOAuthCredentials()` and `_loadApiKeys()` now use platform abstraction

**src/config/default.ts**
- Replace `getCloudflareContext()` with `getPlatformDb()`
- `loadProvidersFromD1()` accepts `SqlClient` instead of `Env`

**app/api/admin/providers/speed-test/route.ts**
- Remove unused `getCloudflareContext()` import and call

**app/api/admin/providers/models/[provider]/route.ts**
- Remove unused `getCloudflareContext()` import and call

### Debug logging added

Added console logs to KeyManager to help troubleshoot 401 errors:
- Database availability check
- SQL query and provider key
- Results count

### Testing
- ✅ `npm run build:vercel` passes
- ✅ `npm test` - 298 tests passed