### PR TITLE
debug: add detailed logging for troubleshooting upstream requests

### DIFF
--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -20,6 +20,7 @@ interface ChatBody {
 
 export async function POST(request: NextRequest) {
   const logger = createLogger();
+  logger.info('=== Chat Completions Request Start ===');
 
   const authResult = await authenticate(request);
   if (!authResult) {
@@ -35,9 +36,11 @@ export async function POST(request: NextRequest) {
 
     const requestedModel = rawBody.model;
     const isStream = rawBody.stream === true;
+    logger.info('Request details', { model: requestedModel, stream: isStream });
 
     const config = await getConfig();
     const { name: providerName, provider, realModel } = resolveProvider(config, requestedModel, 'openai');
+    logger.info('Provider resolved', { providerName, providerEndpoint: provider.endpoint, realModel });
 
     const upstreamProtocol = ProtocolFactory.get('openai');
 
@@ -56,6 +59,12 @@ export async function POST(request: NextRequest) {
       const upstreamApiKey = await upstreamProtocol.getApiKey(db, provider);
       fetchUrl = await upstreamProtocol.getEndpoint(provider, realModel, isStream, upstreamApiKey);
       fetchHeaders = await upstreamProtocol.getHeaders(provider, db, upstreamApiKey);
+      logger.info('Upstream request', { 
+        attempt, 
+        url: fetchUrl, 
+        headers: { ...fetchHeaders, Authorization: fetchHeaders['Authorization'] ? '[REDACTED]' : undefined },
+        body: JSON.stringify(upstreamRequest).substring(0, 200),
+      });
       lastResponse = await fetch(fetchUrl, {
         method: 'POST',
         headers: fetchHeaders,

--- a/src/managers/key.ts
+++ b/src/managers/key.ts
@@ -40,6 +40,10 @@ const _loadApiKeys = async (providerKey: string): Promise<string[]> => {
   console.log('[KeyManager] Query:', query, 'Provider:', providerKey);
   const { results } = await db.prepare(query).bind(providerKey).all();
   console.log('[KeyManager] Results count:', results?.length ?? 0);
+  console.log('[KeyManager] Keys:', results?.map((r: Record<string, unknown>) => {
+    const typedRow = r as unknown as { content: string };
+    return typedRow.content.substring(0, 20) + '...';
+  }));
   if (!results || results.length === 0) {
     throw new Error(`No API keys found for provider: ${providerKey}`);
   }


### PR DESCRIPTION
## Summary

Add comprehensive logging to debug 401/404 upstream errors:

- Log request start marker
- Log request details (model, stream)
- Log provider resolution (name, endpoint, realModel)
- Log upstream request (url, headers, body preview)
- Log API key values (first 20 chars)

## Changes

- app/v1/chat/completions/route.ts - detailed request/response logging
- src/managers/key.ts - log API key values

## Testing
- ✅ `npm run build:vercel` passes