### PR TITLE
fix: Vercel compatibility and upstream request debugging

### DIFF
--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -45,6 +45,8 @@ export async function POST(request: NextRequest) {
     const upstreamProtocol = ProtocolFactory.get('openai');
 
     const upstreamRequest = upstreamProtocol.toStandardRequest(rawBodyObj as ProtocolBody);
+    // Override model with realModel from resolveProvider
+    upstreamRequest.model = realModel;
 
     if (!db) {
       return createJsonResponse({ error: 'D1 database not configured' }, 500);

--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
         attempt, 
         url: fetchUrl, 
         headers: { ...fetchHeaders, Authorization: fetchHeaders['Authorization'] ? '[REDACTED]' : undefined },
-        body: JSON.stringify(upstreamRequest).substring(0, 200),
+        body: JSON.stringify(upstreamRequest).substring(0, 500),
       });
       lastResponse = await fetch(fetchUrl, {
         method: 'POST',


### PR DESCRIPTION
## Summary

Remove getCloudflareContext calls and add detailed logging for debugging upstream requests.

### Changes

**Bug fixes:**
- Remove all direct `getCloudflareContext()` calls from admin routes
- Override model in upstream request with `realModel` from resolveProvider
- Update KeyManager, Config, and admin routes to use `getPlatformDb()`

**Debug logging:**
- Log request details (model, stream)
- Log provider resolution (name, endpoint, realModel)
- Log upstream request (url, headers, body 500 chars)
- Log API key values (first 20 chars)

### Files changed

- src/managers/key.ts
- src/config/default.ts
- src/platforms/index.ts (no longer imports cloudflare)
- app/api/admin/providers/speed-test/route.ts
- app/api/admin/providers/models/[provider]/route.ts
- app/v1/chat/completions/route.ts

### Testing
- ✅ `npm run build:vercel` passes
- ✅ `npm test` passes