### PR TITLE
feat: add OPTIONS handler for CORS preflight on /v1/models

### DIFF
--- a/app/v1/models/route.ts
+++ b/app/v1/models/route.ts
@@ -2,9 +2,18 @@ import { NextRequest } from 'next/server';
 import { authenticate } from '@/lib/auth';
 import { createJsonResponse } from '@/lib/response-helpers';
 import { getConfig } from '@/config';
+import { CORS_HEADERS } from '@/utils/constants';
 import type { ProviderConfig } from '@/types';
 
 export const dynamic = 'force-dynamic';
+
+// Handle CORS preflight requests
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: CORS_HEADERS,
+  });
+}
 
 interface ModelInfo {
   id: string;


### PR DESCRIPTION
## Summary

Add OPTIONS handler to /v1/models endpoint to support CORS preflight requests.

### Problem
Some clients send OPTIONS requests to check CORS support before making actual requests. Without an OPTIONS handler, the endpoint returns 405 Method Not Allowed.

### Solution
Return 204 No Content with CORS headers for OPTIONS requests.

### Changes
- Add OPTIONS export function in app/v1/models/route.ts
- Import CORS_HEADERS from utils/constants

### Testing
- ✅ `npm run build:vercel` passes