### PR TITLE
feat: add GLM preserved thinking parameter support (closes #168)

### DIFF
--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -8,6 +8,7 @@ import type { ProtocolBody } from '@/types';
 import { CORS_HEADERS } from '@/utils/constants';
 import { createLogger } from '@/utils/logger';
 import { getPlatformDb } from '@/platforms';
+import { addGlmThinkingParam } from '@/utils';
 
 export const dynamic = 'force-dynamic';
 
@@ -48,6 +49,9 @@ export async function POST(request: NextRequest) {
     // Override model with realModel from resolveProvider
     upstreamRequest.model = realModel;
 
+    // Add GLM preserved thinking parameter if applicable
+    const requestWithGlmThinking = addGlmThinkingParam(upstreamRequest);
+
     if (!db) {
       return createJsonResponse({ error: 'D1 database not configured' }, 500);
     }
@@ -63,14 +67,14 @@ export async function POST(request: NextRequest) {
       fetchHeaders = await upstreamProtocol.getHeaders(provider, db, upstreamApiKey);
       logger.info('Upstream request', { 
         attempt, 
-        url: fetchUrl, 
+        url: fetchUrl,
         headers: { ...fetchHeaders, Authorization: fetchHeaders['Authorization'] ? '[REDACTED]' : undefined },
-        body: JSON.stringify(upstreamRequest).substring(0, 500),
+        body: JSON.stringify(requestWithGlmThinking).substring(0, 500),
       });
       lastResponse = await fetch(fetchUrl, {
         method: 'POST',
         headers: fetchHeaders,
-        body: JSON.stringify(upstreamRequest),
+        body: JSON.stringify(requestWithGlmThinking),
       });
       if (lastResponse.status !== 429 || attempt === MAX_ATTEMPTS) break;
       logger.warn(`Upstream 429 Rate Limit, retrying...`, { attempt });

--- a/src/utils/glm.ts
+++ b/src/utils/glm.ts
@@ -1,0 +1,29 @@
+import type { ProtocolBody } from '../types';
+
+/**
+ * Adds preserved thinking parameter for GLM models.
+ * GLM models support reserved thinking (保留式思考) via extra_body.thinking.
+ * @see https://www.zhipuai.cn/docs/thinking
+ */
+export function addGlmThinkingParam(request: ProtocolBody): ProtocolBody {
+  const model = (request.model as string | undefined)?.toLowerCase() ?? '';
+
+  if (!model.includes('glm')) {
+    return request;
+  }
+
+  const thinkingConfig = {
+    thinking: {
+      type: 'enabled',
+      clear_thinking: false,
+    },
+  };
+
+  return {
+    ...request,
+    extra_body: {
+      ...(request.extra_body as Record<string, unknown> | undefined),
+      ...thinkingConfig,
+    },
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { createLogger, Logger } from './logger';
 export { createSSEParser } from './sse-parser';
+export { addGlmThinkingParam } from './glm';

--- a/test/unit/utils/glm.test.ts
+++ b/test/unit/utils/glm.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { addGlmThinkingParam } from '../../../src/utils/glm';
+import type { ProtocolBody } from '../../../src/types';
+
+describe('addGlmThinkingParam', () => {
+  const baseRequest: ProtocolBody = {
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'Hello' }],
+  };
+
+  describe('GLM models', () => {
+    it('should add thinking parameter for glm-4 model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'glm-4-0520' };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeDefined();
+      expect((result.extra_body as any).thinking).toEqual({
+        type: 'enabled',
+        clear_thinking: false,
+      });
+    });
+
+    it('should add thinking parameter for glm-3 model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'glm-3-flash' };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).thinking).toEqual({
+        type: 'enabled',
+        clear_thinking: false,
+      });
+    });
+
+    it('should add thinking parameter for GLM model with mixed case', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'GLM-4-Flash' };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).thinking).toEqual({
+        type: 'enabled',
+        clear_thinking: false,
+      });
+    });
+
+    it('should add thinking parameter for models containing glm substring', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'chatglm-4' };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).thinking).toEqual({
+        type: 'enabled',
+        clear_thinking: false,
+      });
+    });
+  });
+
+  describe('Non-GLM models', () => {
+    it('should NOT add thinking parameter for gpt-4 model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'gpt-4' };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeUndefined();
+    });
+
+    it('should NOT add thinking parameter for claude model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'claude-3-opus' };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeUndefined();
+    });
+
+    it('should NOT add thinking parameter for gemini model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'gemini-pro' };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeUndefined();
+    });
+
+    it('should NOT add thinking parameter for empty model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: '' };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeUndefined();
+    });
+
+    it('should NOT add thinking parameter for undefined model', () => {
+      const request: ProtocolBody = { ...baseRequest, model: undefined };
+      const result = addGlmThinkingParam(request);
+
+      expect(result.extra_body).toBeUndefined();
+    });
+  });
+
+  describe('Extra body merging', () => {
+    it('should preserve existing extra_body parameters for GLM models', () => {
+      const request: ProtocolBody = {
+        ...baseRequest,
+        model: 'glm-4',
+        extra_body: {
+          custom_param: 'test_value',
+          temperature: 0.9,
+        },
+      };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).custom_param).toBe('test_value');
+      expect((result.extra_body as any).temperature).toBe(0.9);
+      expect((result.extra_body as any).thinking).toEqual({
+        type: 'enabled',
+        clear_thinking: false,
+      });
+    });
+
+    it('should NOT modify extra_body for non-GLM models', () => {
+      const request: ProtocolBody = {
+        ...baseRequest,
+        model: 'gpt-4',
+        extra_body: {
+          custom_param: 'test_value',
+        },
+      };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).custom_param).toBe('test_value');
+      expect((result.extra_body as any).thinking).toBeUndefined();
+    });
+  });
+
+  describe('Preserved thinking behavior', () => {
+    it('should set clear_thinking to false for preserved thinking', () => {
+      const request: ProtocolBody = { ...baseRequest, model: 'glm-4' };
+      const result = addGlmThinkingParam(request);
+
+      expect((result.extra_body as any).thinking.clear_thinking).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

为  接口添加 GLM 模型保留式思考（Preserved Thinking）参数支持。

## Changes

- **新增**:  - GLM thinking 参数处理工具函数
- **新增**:  - 12 个单元测试覆盖
- **修改**:  - 调用  注入参数

## Technical Details

当请求的模型名称包含 "glm"（大小写不敏感）时，自动向上游请求添加：



 表示**保留式思考**，思考过程会出现在最终响应中。

## Testing

- ✅ 343 tests passing
- Coverage thresholds maintained (70% branches, 85% functions, 80% lines)

Closes #168