### PR TITLE
feat: add auto model support with configurable model pool per provider

### DIFF
--- a/app/api/admin/providers/[id]/route.ts
+++ b/app/api/admin/providers/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 
     const result = await db
       .prepare(
-        `SELECT id, name, type, family, endpoint, key, models, auth_type, sort_order, enabled, created_at, updated_at
+        `SELECT id, name, type, family, endpoint, key, models, auth_type, auto_models, sort_order, enabled, created_at, updated_at
          FROM providers
          WHERE id = ?`
       )
@@ -41,9 +41,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         family: row.family as string,
         endpoint: row.endpoint as string,
         key: row.key as string,
-        models: JSON.parse(row.models as string),
-        auth_type: row.auth_type as string,
-        sort_order: row.sort_order as number,
+    models: JSON.parse(row.models as string),
+    auth_type: row.auth_type as string,
+    auto_models: (row.auto_models as string) || '',
+    sort_order: row.sort_order as number,
         enabled: (row.enabled as number) === 1,
         created_at: row.created_at as string,
         updated_at: row.updated_at as string,
@@ -68,61 +69,64 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       return createJsonResponse({ error: 'id must be a number' }, 400);
     }
 
-    const body = (await request.json()) as {
-      name?: string;
-      type?: string;
-      family?: string;
-      endpoint?: string;
-      key?: string;
-      models?: string[];
-      auth_type?: string;
-      sort_order?: number;
-      enabled?: boolean;
-    };
+  const body = (await request.json()) as {
+    name?: string;
+    type?: string;
+    family?: string;
+    endpoint?: string;
+    key?: string;
+    models?: string[];
+    auth_type?: string;
+    auto_models?: string;
+    sort_order?: number;
+    enabled?: boolean;
+  };
 
-    const existing = await db.prepare('SELECT id FROM providers WHERE id = ?').bind(id).first();
-    if (!existing || !existing.results) {
-      return createNotFoundResponse('Provider not found');
-    }
+  const existing = await db.prepare('SELECT id FROM providers WHERE id = ?').bind(id).first();
+  if (!existing || !existing.results) {
+    return createNotFoundResponse('Provider not found');
+  }
 
-    const existingRow = (await db.prepare('SELECT * FROM providers WHERE id = ?').bind(id).first()).results as Record<string, unknown>;
+  const existingRow = (await db.prepare('SELECT * FROM providers WHERE id = ?').bind(id).first()).results as Record<string, unknown>;
 
-    const name = body.name ?? (existingRow.name as string);
-    const type = body.type ?? (existingRow.type as string);
-    const family = body.family ?? (existingRow.family as string);
-    const endpoint = body.endpoint ?? (existingRow.endpoint as string);
-    const key = body.key ?? (existingRow.key as string);
-    const models = body.models ?? JSON.parse(existingRow.models as string);
-    const auth_type = body.auth_type ?? (existingRow.auth_type as string) ?? 'bearer';
-    const sort_order = body.sort_order ?? (existingRow.sort_order as number);
-    const enabledVal = body.enabled !== undefined ? (body.enabled ? 1 : 0) : (existingRow.enabled as number);
+  const name = body.name ?? (existingRow.name as string);
+  const type = body.type ?? (existingRow.type as string);
+  const family = body.family ?? (existingRow.family as string);
+  const endpoint = body.endpoint ?? (existingRow.endpoint as string);
+  const key = body.key ?? (existingRow.key as string);
+  const models = body.models ?? JSON.parse(existingRow.models as string);
+  const auth_type = body.auth_type ?? (existingRow.auth_type as string) ?? 'bearer';
+  const auto_models = body.auto_models ?? (existingRow.auto_models as string) ?? '';
+  const sort_order = body.sort_order ?? (existingRow.sort_order as number);
+  const enabledVal = body.enabled !== undefined ? (body.enabled ? 1 : 0) : (existingRow.enabled as number);
 
-    const modelsJson = JSON.stringify(models);
+  const modelsJson = JSON.stringify(models);
 
-    await db
-      .prepare(
-        `UPDATE providers
-         SET name = ?, type = ?, family = ?, endpoint = ?, key = ?, models = ?, auth_type = ?, sort_order = ?, enabled = ?, updated_at = datetime('now')
-         WHERE id = ?`
-      )
-      .bind(name, type, family, endpoint, key, modelsJson, auth_type, sort_order, enabledVal, id)
-      .run();
+  await db
+    .prepare(
+      `UPDATE providers
+       SET name = ?, type = ?, family = ?, endpoint = ?, key = ?, models = ?, auth_type = ?, auto_models = ?, sort_order = ?, enabled = ?, updated_at = datetime('now')
+       WHERE id = ?`
+    )
+    .bind(name, type, family, endpoint, key, modelsJson, auth_type, auto_models, sort_order, enabledVal, id)
+    .run();
 
-    return createJsonResponse({
-      success: true,
-      provider: {
-        id,
-        name,
-        type,
-        family,
-        endpoint,
-        key,
-        models,
-        auth_type,
-        sort_order,
-        enabled: enabledVal === 1,
-      },
-    });
+  return createJsonResponse({
+    success: true,
+    provider: {
+      id,
+      name,
+      type,
+      family,
+      endpoint,
+      key,
+      models,
+      auth_type,
+      auto_models,
+      sort_order,
+      enabled: enabledVal === 1,
+    },
+  });
   } catch (error) {
     console.error('Error updating provider:', error);
     return createInternalErrorResponse((error as Error).message);

--- a/app/api/admin/providers/route.ts
+++ b/app/api/admin/providers/route.ts
@@ -14,27 +14,28 @@ export async function GET() {
 
     const result = await db
       .prepare(
-        `SELECT id, name, type, family, endpoint, key, models, auth_type, sort_order, enabled, created_at, updated_at
+        `SELECT id, name, type, family, endpoint, key, models, auth_type, auto_models, sort_order, enabled, created_at, updated_at
          FROM providers
          ORDER BY sort_order ASC`
       )
       .bind()
       .all();
 
-    const providers = (result.results as readonly Record<string, unknown>[]).map((row) => ({
-      id: row.id as number,
-      name: row.name as string,
-      type: row.type as string,
-      family: row.family as string,
-      endpoint: row.endpoint as string,
-      key: row.key as string,
-      models: JSON.parse(row.models as string) as string[],
-      auth_type: row.auth_type as string,
-      sort_order: row.sort_order as number,
-      enabled: (row.enabled as number) === 1,
-      created_at: row.created_at as string,
-      updated_at: row.updated_at as string,
-    }));
+  const providers = (result.results as readonly Record<string, unknown>[]).map((row) => ({
+    id: row.id as number,
+    name: row.name as string,
+    type: row.type as string,
+    family: row.family as string,
+    endpoint: row.endpoint as string,
+    key: row.key as string,
+    models: JSON.parse(row.models as string) as string[],
+    auth_type: row.auth_type as string,
+    auto_models: (row.auto_models as string) || '',
+    sort_order: row.sort_order as number,
+    enabled: (row.enabled as number) === 1,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  }));
 
     return createJsonResponse({ success: true, providers });
   } catch (error) {
@@ -51,19 +52,20 @@ export async function POST(request: NextRequest) {
       return createJsonResponse({ error: 'D1 database not configured' }, 500);
     }
 
-    const body = (await request.json()) as {
-      name?: string;
-      type?: string;
-      family?: string;
-      endpoint?: string;
-      key?: string;
-      models?: string[];
-      auth_type?: string;
-      sort_order?: number;
-      enabled?: boolean;
-    };
+  const body = (await request.json()) as {
+    name?: string;
+    type?: string;
+    family?: string;
+    endpoint?: string;
+    key?: string;
+    models?: string[];
+    auth_type?: string;
+    auto_models?: string;
+    sort_order?: number;
+    enabled?: boolean;
+  };
 
-    const { name, type, family, endpoint, key, models, auth_type, sort_order, enabled } = body;
+  const { name, type, family, endpoint, key, models, auth_type, auto_models, sort_order, enabled } = body;
 
     if (!name || !type || !family || !endpoint || !key) {
       return createJsonResponse({ error: 'name, type, family, endpoint, and key are required' }, 400);
@@ -89,34 +91,35 @@ export async function POST(request: NextRequest) {
     const sortOrder = sort_order ?? 0;
     const enabledVal = enabled !== false ? 1 : 0;
 
-    const result = await db
-      .prepare(
-        `INSERT INTO providers (name, type, family, endpoint, key, models, auth_type, sort_order, enabled, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`
-      )
-      .bind(name, type, family, endpoint, key, modelsJson, authType, sortOrder, enabledVal)
-      .run();
+  const result = await db
+    .prepare(
+      `INSERT INTO providers (name, type, family, endpoint, key, models, auth_type, auto_models, sort_order, enabled, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`
+    )
+    .bind(name, type, family, endpoint, key, modelsJson, authType, auto_models || '', sortOrder, enabledVal)
+    .run();
 
-    const newId = (result.meta as { last_row_id: number }).last_row_id;
+  const newId = (result.meta as { last_row_id: number }).last_row_id;
 
-    return createJsonResponse(
-      {
-        success: true,
-        provider: {
-          id: newId,
-          name,
-          type,
-          family,
-          endpoint,
-          key,
-          models: models || [],
-          auth_type: authType,
-          sort_order: sortOrder,
-          enabled: enabledVal === 1,
-        },
+  return createJsonResponse(
+    {
+      success: true,
+      provider: {
+        id: newId,
+        name,
+        type,
+        family,
+        endpoint,
+        key,
+        models: models || [],
+        auth_type: authType,
+        auto_models: auto_models || '',
+        sort_order: sortOrder,
+        enabled: enabledVal === 1,
       },
-      201
-    );
+    },
+    201
+  );
   } catch (error) {
     console.error('Error creating provider:', error);
     return createInternalErrorResponse((error as Error).message);
@@ -131,20 +134,21 @@ export async function PUT(request: NextRequest) {
       return createJsonResponse({ error: 'D1 database not configured' }, 500);
     }
 
-    const body = (await request.json()) as {
-      id?: number;
-      name?: string;
-      type?: string;
-      family?: string;
-      endpoint?: string;
-      key?: string;
-      models?: string[];
-      auth_type?: string;
-      sort_order?: number;
-      enabled?: boolean;
-    };
+  const body = (await request.json()) as {
+    id?: number;
+    name?: string;
+    type?: string;
+    family?: string;
+    endpoint?: string;
+    key?: string;
+    models?: string[];
+    auth_type?: string;
+    auto_models?: string;
+    sort_order?: number;
+    enabled?: boolean;
+  };
 
-    const { id, name, type, family, endpoint, key, models, auth_type, sort_order, enabled } = body;
+  const { id, name, type, family, endpoint, key, models, auth_type, auto_models, sort_order, enabled } = body;
 
     if (!id) {
       return createJsonResponse({ error: 'id is required' }, 400);
@@ -158,41 +162,43 @@ export async function PUT(request: NextRequest) {
     const modelsJson = JSON.stringify(models || []);
     const enabledVal = enabled !== false ? 1 : 0;
 
-    await db
-      .prepare(
-        `UPDATE providers
-         SET name = ?, type = ?, family = ?, endpoint = ?, key = ?, models = ?, auth_type = ?, sort_order = ?, enabled = ?, updated_at = datetime('now')
-         WHERE id = ?`
-      )
-      .bind(
-        name || '',
-        type || '',
-        family || '',
-        endpoint || '',
-        key || '',
-        modelsJson,
-        auth_type || 'bearer',
-        sort_order ?? 0,
-        enabledVal,
-        id
-      )
-      .run();
+  await db
+    .prepare(
+      `UPDATE providers
+       SET name = ?, type = ?, family = ?, endpoint = ?, key = ?, models = ?, auth_type = ?, auto_models = ?, sort_order = ?, enabled = ?, updated_at = datetime('now')
+       WHERE id = ?`
+    )
+    .bind(
+      name || '',
+      type || '',
+      family || '',
+      endpoint || '',
+      key || '',
+      modelsJson,
+      auth_type || 'bearer',
+      auto_models || '',
+      sort_order ?? 0,
+      enabledVal,
+      id
+    )
+    .run();
 
-    return createJsonResponse({
-      success: true,
-      provider: {
-        id,
-        name,
-        type,
-        family,
-        endpoint,
-        key,
-        models: models || [],
-        auth_type: auth_type || 'bearer',
-        sort_order: sort_order ?? 0,
-        enabled: enabledVal === 1,
-      },
-    });
+  return createJsonResponse({
+    success: true,
+    provider: {
+      id,
+      name,
+      type,
+      family,
+      endpoint,
+      key,
+      models: models || [],
+      auth_type: auth_type || 'bearer',
+      auto_models: auto_models || '',
+      sort_order: sort_order ?? 0,
+      enabled: enabledVal === 1,
+    },
+  });
   } catch (error) {
     console.error('Error updating provider:', error);
     return createInternalErrorResponse((error as Error).message);

--- a/app/v1/models/route.ts
+++ b/app/v1/models/route.ts
@@ -60,21 +60,33 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      if (Array.isArray(provider.models)) {
-        provider.models.forEach((modelId: string) => {
-          // Return format: providerName/modelId (e.g., doubao/ark-code-latest)
-          const prefixedModelId = `${providerName}/${modelId}`;
-          if (!seenIds.has(prefixedModelId)) {
-            seenIds.add(prefixedModelId);
-            modelsList.push({
-              id: prefixedModelId,
-              object: 'model',
-              created: 1739116800,
-              owned_by: providerName,
-            });
-          }
+    if (Array.isArray(provider.models)) {
+      provider.models.forEach((modelId: string) => {
+        // Return format: providerName/modelId (e.g., doubao/ark-code-latest)
+        const prefixedModelId = `${providerName}/${modelId}`;
+        if (!seenIds.has(prefixedModelId)) {
+          seenIds.add(prefixedModelId);
+          modelsList.push({
+            id: prefixedModelId,
+            object: 'model',
+            created: 1739116800,
+            owned_by: providerName,
+          });
+        }
+      });
+
+      // Expose "auto" model for each provider
+      const autoModelId = `${providerName}/auto`;
+      if (!seenIds.has(autoModelId)) {
+        seenIds.add(autoModelId);
+        modelsList.push({
+          id: autoModelId,
+          object: 'model',
+          created: 1739116800,
+          owned_by: providerName,
         });
       }
+    }
     }
 
     return createJsonResponse({

--- a/app/v1beta/models/route.ts
+++ b/app/v1beta/models/route.ts
@@ -48,23 +48,38 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      if (Array.isArray(typedProvider.models)) {
-        typedProvider.models.forEach((modelId: string) => {
-          if (!seenIds.has(modelId)) {
-            seenIds.add(modelId);
-            modelsList.push({
-              name: `models/${modelId}`,
-              baseModelId: modelId.split('-').slice(0, -1).join('-') || modelId,
-              version: '1.0',
-              displayName: modelId,
-              description: `Gemini model: ${modelId}`,
-              inputTokenLimit: 1048576,
-              outputTokenLimit: 8192,
-              supportedGenerationMethods: ['generateContent'],
-            });
-          }
+    if (Array.isArray(typedProvider.models)) {
+      typedProvider.models.forEach((modelId: string) => {
+        if (!seenIds.has(modelId)) {
+          seenIds.add(modelId);
+          modelsList.push({
+            name: `models/${modelId}`,
+            baseModelId: modelId.split('-').slice(0, -1).join('-') || modelId,
+            version: '1.0',
+            displayName: modelId,
+            description: `Gemini model: ${modelId}`,
+            inputTokenLimit: 1048576,
+            outputTokenLimit: 8192,
+            supportedGenerationMethods: ['generateContent'],
+          });
+        }
+      });
+
+      // Expose "auto" model for Gemini providers
+      if (!seenIds.has('auto')) {
+        seenIds.add('auto');
+        modelsList.push({
+          name: 'models/auto',
+          baseModelId: 'auto',
+          version: '1.0',
+          displayName: 'auto',
+          description: 'Auto model: randomly picks from provider models',
+          inputTokenLimit: 1048576,
+          outputTokenLimit: 8192,
+          supportedGenerationMethods: ['generateContent'],
         });
       }
+    }
     }
 
     const response: GeminiModelsResponse = {

--- a/prisma/migrations/add_auto_models.sql
+++ b/prisma/migrations/add_auto_models.sql
@@ -1,0 +1,6 @@
+-- Add auto_models column to providers table
+-- Stores comma-separated model IDs for "auto" model resolution
+-- Empty string = randomly pick from the provider's full models list
+-- Comma-separated values = randomly pick from the specified subset
+
+ALTER TABLE providers ADD COLUMN auto_models TEXT DEFAULT '';

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -13,7 +13,7 @@ async function loadProvidersFromD1(db: SqlClient): Promise<Config | null> {
 
   try {
     const { results } = await db
-      .prepare('SELECT name, type, family, endpoint, key, models, auth_type FROM providers WHERE enabled = 1 ORDER BY sort_order ASC')
+      .prepare('SELECT name, type, family, endpoint, key, models, auth_type, auto_models FROM providers WHERE enabled = 1 ORDER BY sort_order ASC')
       .bind()
       .all();
 
@@ -35,6 +35,7 @@ async function loadProvidersFromD1(db: SqlClient): Promise<Config | null> {
           key: row.key as string,
           models,
           ...(row.auth_type ? { authType: row.auth_type as ProviderConfig['authType'] } : {}),
+          ...(row.auto_models ? { autoModels: row.auto_models as string } : {}),
         };
 
         if (!defaultProvider) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,8 +14,6 @@ export async function getConfig(): Promise<Config> {
 }
 
 export function resolveProvider(config: Config, model: string, family?: ProtocolFamily): ResolvedProvider {
-  const realModel = model;
-
   // New mode: prefixed model format (e.g., "doubao/ark-code-latest")
   if (model.includes('/')) {
     const colonIndex = model.indexOf('/');
@@ -25,6 +23,13 @@ export function resolveProvider(config: Config, model: string, family?: Protocol
     // Check if this provider exists in config
     if (config.providers[providerNameFromModel]) {
       const provider = config.providers[providerNameFromModel];
+
+      // Auto model resolution: "provider/auto" → pick a random model
+      if (actualModelName === 'auto') {
+        const resolvedModel = resolveAutoModel(provider);
+        return { name: providerNameFromModel, provider, realModel: resolvedModel };
+      }
+
       // Validate model exists in provider's model list
       if (provider.models && provider.models.includes(actualModelName)) {
         // Valid new mode - use the prefixed provider and model
@@ -35,20 +40,44 @@ export function resolveProvider(config: Config, model: string, family?: Protocol
     // Provider doesn't exist or model not in list - fall through to legacy mode
   }
 
+  // Bare "auto" → resolve from default provider
+  if (model === 'auto') {
+    const providerName = config.default_provider;
+    const provider = config.providers[providerName];
+    const resolvedModel = resolveAutoModel(provider);
+    return { name: providerName, provider, realModel: resolvedModel };
+  }
+
   // Legacy mode: search for model in all providers
   let fallbackProviderName: string | null = null;
 
   for (const [name, p] of Object.entries(config.providers)) {
-    if (p.models && p.models.includes(realModel)) {
+    if (p.models && p.models.includes(model)) {
       if (!fallbackProviderName) fallbackProviderName = name;
       if (family && p.family === family) {
-        return { name, provider: p, realModel };
+        return { name, provider: p, realModel: model };
       }
     }
   }
 
   const finalName = fallbackProviderName || config.default_provider;
-  return { name: finalName, provider: config.providers[finalName], realModel };
+  return { name: finalName, provider: config.providers[finalName], realModel: model };
+}
+
+/**
+ * Resolve "auto" model: pick a random model from autoModels (if configured) or models list.
+ */
+function resolveAutoModel(provider: ProviderConfig): string {
+  const autoModelsStr = provider.autoModels?.trim();
+  const pool = autoModelsStr
+    ? autoModelsStr.split(',').map(m => m.trim()).filter(Boolean)
+    : provider.models || [];
+
+  if (pool.length === 0) {
+    return 'auto'; // Fallback: no models available
+  }
+
+  return pool[Math.floor(Math.random() * pool.length)];
 }
 
 export const ConfigManager = {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -35,6 +35,7 @@ export interface ProviderConfig {
   endpoint: string;
   key: string;
   models: string[];
+  autoModels?: string; // Comma-separated model IDs for "auto" resolution; empty = random from models
   authType?: AuthType; // Optional: defaults to 'header' for Anthropic, 'bearer' for OpenAI
 }
 

--- a/test/unit/config/index.test.ts
+++ b/test/unit/config/index.test.ts
@@ -111,15 +111,97 @@ describe('Config', () => {
       expect(result.provider).toBeUndefined();
     });
 
-    it('should resolve provider with prefixed model format', () => {
-      const config = mockConfig;
+  it('should resolve provider with prefixed model format', () => {
+    const config = mockConfig;
 
-      const result = resolveProvider(config, 'longcat/LongCat-Flash-Chat');
+    const result = resolveProvider(config, 'longcat/LongCat-Flash-Chat');
+
+    expect(result.name).toBe('longcat');
+    expect(result.realModel).toBe('LongCat-Flash-Chat');
+  });
+
+  describe('auto model resolution', () => {
+    it('should resolve "provider/auto" by randomly picking from provider models when autoModels is empty', () => {
+      const result = resolveProvider(mockConfig, 'longcat/auto');
 
       expect(result.name).toBe('longcat');
-      expect(result.realModel).toBe('LongCat-Flash-Chat');
+      expect(['LongCat-Flash-Chat', 'LongCat-Flash-Lite']).toContain(result.realModel);
+    });
+
+    it('should resolve "provider/auto" by picking from autoModels when configured', () => {
+      const config: Config = {
+        providers: {
+          longcat: {
+            type: 'openai',
+            family: 'openai',
+            endpoint: 'https://api.longcat.chat/openai',
+            key: 'LongCat',
+            models: ['LongCat-Flash-Chat', 'LongCat-Flash-Lite', 'LongCat-Flash-Thinking'],
+            autoModels: 'LongCat-Flash-Chat,LongCat-Flash-Lite',
+          },
+        },
+        default_provider: 'longcat',
+      };
+
+      const result = resolveProvider(config, 'longcat/auto');
+
+      expect(result.name).toBe('longcat');
+      expect(['LongCat-Flash-Chat', 'LongCat-Flash-Lite']).toContain(result.realModel);
+      // Should never pick a model outside autoModels
+      expect(result.realModel).not.toBe('LongCat-Flash-Thinking');
+    });
+
+    it('should resolve bare "auto" from default provider', () => {
+      const result = resolveProvider(mockConfig, 'auto');
+
+      expect(result.name).toBe('longcat');
+      expect(['LongCat-Flash-Chat', 'LongCat-Flash-Lite']).toContain(result.realModel);
+    });
+
+    it('should resolve "auto" with autoModels containing spaces', () => {
+      const config: Config = {
+        providers: {
+          longcat: {
+            type: 'openai',
+            family: 'openai',
+            endpoint: 'https://api.longcat.chat/openai',
+            key: 'LongCat',
+            models: ['LongCat-Flash-Chat', 'LongCat-Flash-Lite', 'LongCat-Flash-Thinking'],
+            autoModels: '  LongCat-Flash-Chat , LongCat-Flash-Lite  ',
+          },
+        },
+        default_provider: 'longcat',
+      };
+
+      const result = resolveProvider(config, 'longcat/auto');
+
+      expect(result.name).toBe('longcat');
+      expect(['LongCat-Flash-Chat', 'LongCat-Flash-Lite']).toContain(result.realModel);
+      expect(result.realModel).not.toBe('LongCat-Flash-Thinking');
+    });
+
+    it('should fall back to full model list when autoModels has no valid entries', () => {
+      const config: Config = {
+        providers: {
+          longcat: {
+            type: 'openai',
+            family: 'openai',
+            endpoint: 'https://api.longcat.chat/openai',
+            key: 'LongCat',
+            models: ['LongCat-Flash-Chat', 'LongCat-Flash-Lite'],
+            autoModels: '   ',
+          },
+        },
+        default_provider: 'longcat',
+      };
+
+      const result = resolveProvider(config, 'longcat/auto');
+
+      expect(result.name).toBe('longcat');
+      expect(['LongCat-Flash-Chat', 'LongCat-Flash-Lite']).toContain(result.realModel);
     });
   });
+});
 
   describe('ConfigManager', () => {
     it('should expose getConfig function', () => {


### PR DESCRIPTION
## Summary

Closes #170

Add an `auto` model to each provider that randomly resolves to a real model from a configurable pool.

## How It Works

```
Client requests model "doubao/auto"
  → resolveProvider detects "auto"
  → reads provider.autoModels
  → empty string  → randomly picks from provider.models (all models)
  → "model-a,model-b" → randomly picks from specified list
  → returns { name, config, realModel: randomly-chosen-model }
```

## Changes

| File | Change |
|------|--------|
| `src/types/provider.ts` | Add `autoModels?: string` to `ProviderConfig` |
| `src/config/index.ts` | Add auto model resolution in `resolveProvider` |
| `src/config/default.ts` | Read `auto_models` column from D1 |
| `prisma/migrations/add_auto_models.sql` | ALTER TABLE: add `auto_models TEXT DEFAULT ''` |
| `app/v1/models/route.ts` | Expose `providerName/auto` in models list |
| `app/v1beta/models/route.ts` | Expose `models/auto` in Gemini models list |
| `app/api/admin/providers/route.ts` | CRUD support for `auto_models` field |
| `app/api/admin/providers/[id]/route.ts` | Single-provider CRUD support |
| `test/unit/config/index.test.ts` | 5 new tests for auto model resolution |

## Testing

```
✓ 24 test files, 348 tests passed
✓ 5 new tests for auto model resolution (empty autoModels, specified list, prefixed format)
```

## Usage

1. Run migration: `add_auto_models.sql`
2. Set `auto_models` via Admin API:
   - Empty string = random from all provider models
   - `model-a,model-b` = random from specified subset
3. Client requests: `POST /v1/chat/completions` with `model: "doubao/auto"`
4. Gateway resolves to a random model and forwards